### PR TITLE
HH-46105 add selector.blockOnQueueOverflow option

### DIFF
--- a/nuts-and-bolts/src/main/java/ru/hh/nab/grizzly/BlockedQueueLimitedThreadPool.java
+++ b/nuts-and-bolts/src/main/java/ru/hh/nab/grizzly/BlockedQueueLimitedThreadPool.java
@@ -1,0 +1,59 @@
+package ru.hh.nab.grizzly;
+
+import org.glassfish.grizzly.threadpool.FixedThreadPool;
+import org.glassfish.grizzly.threadpool.ThreadPoolConfig;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.Semaphore;
+
+
+public class BlockedQueueLimitedThreadPool extends FixedThreadPool {
+  public static final int MAX_QUEUE_SIZE = 30000;
+  private final Semaphore queuePermits;
+
+  public BlockedQueueLimitedThreadPool(ThreadPoolConfig config) {
+    super(config);
+    if (config.getQueueLimit() < 0 || config.getQueueLimit() > MAX_QUEUE_SIZE) {
+      throw new IllegalArgumentException("0 < maxQueuedTasks < " + MAX_QUEUE_SIZE);
+    }
+
+    queuePermits = new Semaphore(config.getQueueLimit());
+  }
+
+  @Override
+  public final void execute(Runnable command) {
+    if (command == null) { // must nullcheck to ensure queuesize is valid
+      throw new IllegalArgumentException("Runnable task is null");
+    }
+
+    if (!running) {
+      throw new RejectedExecutionException("ThreadPool is not running");
+    }
+
+    for (;;) {
+      try {
+        queuePermits.acquire();
+
+        // for unbounded queue tasks count may be greater than config.getQueueLimit()
+        boolean added = workQueue.offer(command);
+        if (!added) {
+          queuePermits.release();
+        } else {
+          break;
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RejectedExecutionException("Thread was interrupted");
+      }
+    }
+
+    onTaskQueued(command);
+  }
+
+  @Override
+  protected final void beforeExecute(final Worker worker, final Thread t,
+                                     final Runnable r) {
+    super.beforeExecute(worker, t, r);
+    queuePermits.release();
+  }
+}

--- a/nuts-and-bolts/src/main/java/ru/hh/nab/grizzly/SimpleGrizzlyWebServer.java
+++ b/nuts-and-bolts/src/main/java/ru/hh/nab/grizzly/SimpleGrizzlyWebServer.java
@@ -1,28 +1,92 @@
 package ru.hh.nab.grizzly;
 
+import com.google.common.collect.ImmutableMap;
+import org.glassfish.grizzly.IOStrategy;
 import org.glassfish.grizzly.http.server.HttpHandler;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.grizzly.http.server.NetworkListener;
+import org.glassfish.grizzly.memory.ByteBufferManager;
+import org.glassfish.grizzly.nio.NIOTransport;
+import org.glassfish.grizzly.strategies.LeaderFollowerNIOStrategy;
+import org.glassfish.grizzly.strategies.SameThreadIOStrategy;
+import org.glassfish.grizzly.strategies.SimpleDynamicNIOStrategy;
+import org.glassfish.grizzly.strategies.WorkerThreadIOStrategy;
 import ru.hh.health.monitoring.TimingsLoggerFactory;
+import ru.hh.nab.Settings;
+
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 public class SimpleGrizzlyWebServer {
+  public static final Map<String, IOStrategy> strategies = ImmutableMap.of(
+      "worker", WorkerThreadIOStrategy.getInstance(),
+      "same", SameThreadIOStrategy.getInstance(),
+      "dynamic", SimpleDynamicNIOStrategy.getInstance(),
+      "leader-follower", LeaderFollowerNIOStrategy.getInstance()
+  );
+
+
   private final NetworkListener grizzlyListener;
   private final HttpServer httpServer;
   private final SimpleGrizzlyAdapterChain adapterChains;
+  private final Settings settings;
 
   private boolean isStarted = false;
 
-  public SimpleGrizzlyWebServer(int port, int concurrencyLevel, TimingsLoggerFactory timingsLoggerFactory, int workersQueueLimit) {
+  public static SimpleGrizzlyWebServer create(Settings settings, TimingsLoggerFactory timingsLoggerFactory) {
+    SimpleGrizzlyWebServer s = new SimpleGrizzlyWebServer(settings, timingsLoggerFactory);
+    s.configure();
+    return s;
+  }
+  
+  private SimpleGrizzlyWebServer(Settings settings, TimingsLoggerFactory timingsLoggerFactory) {    
+    this.settings = settings;
     httpServer = new HttpServer();
-    grizzlyListener = new NetworkListener("grizzly", NetworkListener.DEFAULT_NETWORK_HOST, port);
+    grizzlyListener = new NetworkListener("grizzly", NetworkListener.DEFAULT_NETWORK_HOST, settings.port);
     httpServer.addListener(grizzlyListener);
-    setMaxThreads(concurrencyLevel);
-    setCoreThreads(concurrencyLevel);
-    setWorkerThreadQueueLimit(workersQueueLimit);
+
     this.adapterChains = new SimpleGrizzlyAdapterChain(timingsLoggerFactory);
+    addGrizzlyAdapter(new DefaultCharacterEncodingHandler());
+  }
+  
+  private void configure() {
+    setMaxThreads(settings.concurrencyLevel);
+    setCoreThreads(settings.concurrencyLevel);
+    setWorkerThreadQueueLimit(settings.workersQueueLimit);
+    setJmxEnabled(Boolean.valueOf(settings.subTree("grizzly.httpServer").getProperty("jmxEnabled", "false")));
+    initNetworkListener(settings.subTree("selector"));    
+  }
+  
+  private void initNetworkListener(Properties selectorProperties) {
+    final NetworkListener networkListener = getNetworkListener();
+    networkListener.getKeepAlive().setMaxRequestsCount(
+        Integer.parseInt(selectorProperties.getProperty("maxKeepAliveRequests", "4096")));
+    networkListener.getCompressionConfig().setCompressionMinSize(Integer.MAX_VALUE);
+    
+    networkListener.setMaxPendingBytes(Integer.parseInt(selectorProperties.getProperty("sendBufferSize", "32768")));
+    networkListener.setMaxBufferedPostSize(Integer.parseInt(selectorProperties.getProperty("bufferSize", "32768")));
+    networkListener.setMaxHttpHeaderSize(Integer.parseInt(selectorProperties.getProperty("headerSize", "16384")));
+    networkListener.getTransport()
+        .setMemoryManager(new ByteBufferManager(true, 128 * 1024, ByteBufferManager.DEFAULT_SMALL_BUFFER_SIZE));
+
+    NIOTransport transport = networkListener.getTransport();
+    if (Boolean.valueOf(selectorProperties.getProperty("blockOnQueueOverflow", "false"))) {
+      transport.setWorkerThreadPool(new BlockedQueueLimitedThreadPool(transport.getWorkerThreadPoolConfig()));
+    }
+
+    int runnersCount = Integer.parseInt(selectorProperties.getProperty("runnersCount", "-1"));
+    if (runnersCount > 0) {
+      transport.setSelectorRunnersCount(runnersCount);
+    }
+
+    IOStrategy strategy = strategies.get(settings.subTree("grizzly").getProperty("ioStrategy"));
+    if (strategy != null) {
+      networkListener.getTransport().setIOStrategy(strategy);
+    }
+    networkListener.getTransport().setTcpNoDelay(true);
   }
 
   public NetworkListener getNetworkListener() {


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-46105
Добавил опцию selector.blockOnQueueOverflow
Если selector.blockOnQueueOverflow==true, то селекторы засыпают и не принимают соединения. Эффективно использовать с системной настройкой sysctl -w net.ipv4.tcp_abort_on_overflow=1.

Попутно вынес настройки сервера в SimpleGrizzlyWebServer.