### PR TITLE
[adding-session-manager] added the ability to create a SessionManager

### DIFF
--- a/nuts-and-bolts/src/main/java/ru/hh/nab/jetty/JettyServerFactory.java
+++ b/nuts-and-bolts/src/main/java/ru/hh/nab/jetty/JettyServerFactory.java
@@ -69,7 +69,21 @@ public abstract class JettyServerFactory {
     server.setStopAtShutdown(true);
     server.setStopTimeout(getIntProperty(props, "serverStopTimeout", 5000));
 
-    server.setHandler(createWebapp(httpServlet));
+    if (Boolean.parseBoolean(settings.subTree("session-manager").getProperty("enabled"))) {
+      HashSessionIdManager hashSessionIdManager = new HashSessionIdManager();
+      server.setSessionIdManager(hashSessionIdManager);
+
+      ContextHandler context = new ContextHandler("/");
+      server.setHandler(context);
+
+      HashSessionManager manager = new HashSessionManager();
+      SessionHandler sessions = new SessionHandler(manager);
+
+      context.setHandler(sessions);
+      sessions.setHandler(createWebapp(httpServlet));
+    } else {
+      server.setHandler(createWebapp(httpServlet));
+    }
 
     return server;
   }


### PR DESCRIPTION
Для проекта хамелеон, использующего наб, необходим механизм сессий. Для использования HttpSession необходим SessionManager, однако создавать его лучше всего в фабрике джетти-сервера. В этом пул-реквесте добавлена возможность создавать менеджера при определенной настройке в файле settings, в случае ее отсутствия все остается как прежде.