### PR TITLE
HH-100964 throw original exception from ExecuteOnDataSourceAspect

### DIFF
--- a/nab-hibernate/src/main/java/ru/hh/nab/hibernate/transaction/ExecuteOnDataSource.java
+++ b/nab-hibernate/src/main/java/ru/hh/nab/hibernate/transaction/ExecuteOnDataSource.java
@@ -6,6 +6,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import ru.hh.nab.datasource.DataSourceType;
 
+/**
+ * Warning: unlike {@link org.springframework.transaction.annotation.Transactional}
+ * or {@link javax.transaction.Transactional},
+ * transactions created by this annotation will rollback on any exception.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface ExecuteOnDataSource {

--- a/nab-hibernate/src/main/java/ru/hh/nab/hibernate/transaction/ExecuteOnDataSourceAspect.java
+++ b/nab-hibernate/src/main/java/ru/hh/nab/hibernate/transaction/ExecuteOnDataSourceAspect.java
@@ -30,7 +30,12 @@ public class ExecuteOnDataSourceAspect {
     TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
     transactionTemplate.setPropagationBehavior(executeOnDataSource.writableTx() ? PROPAGATION_REQUIRED : PROPAGATION_NOT_SUPPORTED);
     transactionTemplate.setReadOnly(!executeOnDataSource.writableTx());
-    return DataSourceContextUnsafe.executeOn(dataSourceName, executeOnDataSource.overrideByRequestScope(),
-        () -> transactionTemplate.execute(new ExecuteOnDataSourceTransactionCallback(pjp, sessionFactory, executeOnDataSource)));
+
+    try {
+      return DataSourceContextUnsafe.executeOn(dataSourceName, executeOnDataSource.overrideByRequestScope(),
+          () -> transactionTemplate.execute(new ExecuteOnDataSourceTransactionCallback(pjp, sessionFactory, executeOnDataSource)));
+    } catch (ExecuteOnDataSourceWrappedException e) {
+      throw e.getCause();
+    }
   }
 }

--- a/nab-hibernate/src/main/java/ru/hh/nab/hibernate/transaction/ExecuteOnDataSourceTransactionCallback.java
+++ b/nab-hibernate/src/main/java/ru/hh/nab/hibernate/transaction/ExecuteOnDataSourceTransactionCallback.java
@@ -33,7 +33,7 @@ public class ExecuteOnDataSourceTransactionCallback implements TransactionCallba
     } catch (RuntimeException | Error e) {
       throw e;
     } catch (Throwable e) {
-      throw new RuntimeException(e);
+      throw new ExecuteOnDataSourceWrappedException(e);
     } finally {
       if (session != null && initialCacheMode != null) {
         session.setCacheMode(initialCacheMode);

--- a/nab-hibernate/src/main/java/ru/hh/nab/hibernate/transaction/ExecuteOnDataSourceWrappedException.java
+++ b/nab-hibernate/src/main/java/ru/hh/nab/hibernate/transaction/ExecuteOnDataSourceWrappedException.java
@@ -1,0 +1,9 @@
+package ru.hh.nab.hibernate.transaction;
+
+import static java.util.Objects.requireNonNull;
+
+final class ExecuteOnDataSourceWrappedException extends RuntimeException {
+  public ExecuteOnDataSourceWrappedException(Throwable cause) {
+    super("Checked exception from @ExecuteOnDataSource", requireNonNull(cause));
+  }
+}

--- a/nab-tests/src/test/java/ru/hh/nab/datasource/ExecuteOnDataSourceAspectTest.java
+++ b/nab-tests/src/test/java/ru/hh/nab/datasource/ExecuteOnDataSourceAspectTest.java
@@ -1,5 +1,6 @@
 package ru.hh.nab.datasource;
 
+import java.io.IOException;
 import javax.inject.Inject;
 import javax.transaction.Transactional;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -9,6 +10,7 @@ import org.junit.After;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
 import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.assertNotNull;
@@ -73,6 +75,34 @@ public class ExecuteOnDataSourceAspectTest extends HibernateTestBase {
     assertHibernateIsNotInitialized();
     testService.customWrite();
     assertHibernateIsNotInitialized();
+  }
+
+  @Test
+  public void testThrowCheckedException() {
+    String message = "test for @ExecuteOnDataSource";
+
+    assertHibernateIsNotInitialized();
+    try {
+      testService.throwCheckedException(message);
+      fail("Expected exception was not thrown");
+    } catch (IOException e) {
+      assertEquals(IOException.class, e.getClass());
+      assertEquals(message, e.getMessage());
+    }
+  }
+
+  @Test
+  public void testThrowUncheckedException() {
+    String message = "test for @ExecuteOnDataSource";
+
+    assertHibernateIsNotInitialized();
+    try {
+      testService.throwUncheckedException(message);
+      fail("Expected exception was not thrown");
+    } catch (IllegalArgumentException e) {
+      assertEquals(IllegalArgumentException.class, e.getClass());
+      assertEquals(message, e.getMessage());
+    }
   }
 
   private static void assertHibernateIsNotInitialized() {
@@ -151,6 +181,16 @@ public class ExecuteOnDataSourceAspectTest extends HibernateTestBase {
       assertNotNull(sessionFactory.getCurrentSession());
       assertTrue(isSynchronizationActive());
       assertTrue(isActualTransactionActive());
+    }
+
+    @ExecuteOnDataSource(dataSourceType = WRITABLE_DATASOURCE)
+    public void throwCheckedException(String message) throws IOException {
+      throw new IOException(message);
+    }
+
+    @ExecuteOnDataSource(dataSourceType = WRITABLE_DATASOURCE)
+    public void throwUncheckedException(String message) {
+      throw new IllegalArgumentException(message);
     }
   }
 


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-100964

Выкидываем изначальное (а не обёрнутое) исключение из метода, помеченного `@ExecuteOnDataSource`.