### PR TITLE
HH-101449 up spring to 5.2.2.RELEASE, up jackson to 2.10.0

### DIFF
--- a/nab-logging/pom.xml
+++ b/nab-logging/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.databind.version}</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>

--- a/nab-starter/pom.xml
+++ b/nab-starter/pom.xml
@@ -156,7 +156,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.databind.version}</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,13 @@
     </modules>
 
     <properties>
-        <spring.version>5.1.6.RELEASE</spring.version>
+        <spring.version>5.2.2.RELEASE</spring.version>
         <jersey.version>2.29.1</jersey.version>
         <hibernate.version>5.2.10.Final</hibernate.version>
         <postgres.jdbc.version>42.2.5</postgres.jdbc.version>
         <hhmetrics.version>0.19</hhmetrics.version>
         <jetty.version>9.4.15.v20190215</jetty.version>
-        <jackson.version>2.9.10</jackson.version>
-        <jackson.databind.version>2.9.10</jackson.databind.version>
+        <jackson.version>2.10.0</jackson.version>
         <slf4j.version>1.7.28</slf4j.version>
         <logback.version>1.2.3</logback.version>
         <jclient.version>1.6.3</jclient.version>


### PR DESCRIPTION
В рамках https://jira.hh.ru/browse/PORTFOLIO-7487 хотим поднять спринг до 5.2.2 и jackson до 2.10.0, чтоб спринг-кафку 2.3.4 использовать.

В хх.ру тесты прогнал с новым набом/спрингом/jackon https://github.com/hhru/hh.ru/pull/6730