### PR TITLE
HH-101486 implement kafka listener

### DIFF
--- a/nab-jclient/pom.xml
+++ b/nab-jclient/pom.xml
@@ -15,7 +15,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>${groupId}</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>nab-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nab-kafka/pom.xml
+++ b/nab-kafka/pom.xml
@@ -5,11 +5,14 @@
     <parent>
         <artifactId>nuts-and-bolts-parent</artifactId>
         <groupId>ru.hh.nab</groupId>
-        <version>4.22.13-SNAPSHOT</version>
+        <version>4.22.14-SNAPSHOT</version>
+        <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>nab-kafka</artifactId>
+
+    <name>nuts'n'bolts kafka</name>
 
     <dependencies>
         <dependency>
@@ -18,9 +21,20 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>ru.hh.nab</groupId>
+            <artifactId>nab-metrics</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
-            <version>2.3.4.RELEASE</version>
+            <version>${spring.kafka.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/nab-kafka/pom.xml
+++ b/nab-kafka/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>nuts-and-bolts-parent</artifactId>
+        <groupId>ru.hh.nab</groupId>
+        <version>4.22.13-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>nab-kafka</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>ru.hh.nab</groupId>
+            <artifactId>nab-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+            <version>2.3.4.RELEASE</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/Ack.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/Ack.java
@@ -1,0 +1,7 @@
+package ru.hh.nab.kafka.consumer;
+
+public interface Ack {
+
+  void acknowledge();
+
+}

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/DefaultListenerFactory.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/DefaultListenerFactory.java
@@ -1,0 +1,84 @@
+package ru.hh.nab.kafka.consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.BatchAcknowledgingMessageListener;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.GenericMessageListener;
+import org.springframework.kafka.listener.SeekToCurrentBatchErrorHandler;
+import ru.hh.nab.kafka.util.ConfigProvider;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+
+public class DefaultListenerFactory implements ListenerFactory {
+
+  private final ConfigProvider configProvider;
+  private final DeserializerSupplier deserializerSupplier;
+
+  public DefaultListenerFactory(ConfigProvider configProvider, DeserializerSupplier deserializerSupplier) {
+    this.configProvider = configProvider;
+    this.deserializerSupplier = deserializerSupplier;
+  }
+
+  public <T> Listener listenTopic(String topicName,
+                                  String operationName,
+                                  Class<T> messageClass,
+                                  ListenStrategy<T> messageListener) {
+
+    ConsumerFactory<String, T> consumerFactory = getConsumerFactory(topicName, messageClass);
+
+    ContainerProperties containerProperties = getListenerContainerProperties(topicName, operationName, adaptToSpring(messageListener));
+    var container = getMessageListenerContainer(consumerFactory, containerProperties);
+    container.start();
+
+    return container::stop;
+  }
+
+  private <T> BatchAcknowledgingMessageListener<String, T> adaptToSpring(ListenStrategy<T> messageListener) {
+    return (data, acknowledgment) -> messageListener.onMessagesBatch(
+        data.stream().map(ConsumerRecord::value).collect(Collectors.toList()),
+        acknowledgment::acknowledge
+    );
+  }
+
+  private <T> ConcurrentMessageListenerContainer<String, T> getMessageListenerContainer(ConsumerFactory<String, T> consumerFactory,
+                                                                                        ContainerProperties containerProperties) {
+
+    var container = new ConcurrentMessageListenerContainer<>(consumerFactory, containerProperties);
+    container.setBatchErrorHandler(new SeekToCurrentBatchErrorHandler());
+
+    return container;
+  }
+
+  private <T> ConsumerFactory<String, T> getConsumerFactory(String topicName, Class<T> messageClass) {
+    Map<String, Object> consumerConfig = configProvider.getConsumerConfig(topicName);
+
+    return new DefaultKafkaConsumerFactory<>(
+        consumerConfig,
+        new StringDeserializer(),
+        deserializerSupplier.supplyFor(messageClass)
+    );
+  }
+
+  private ContainerProperties getListenerContainerProperties(String topic, String operationName, GenericMessageListener<?> messageListener) {
+    var containerProperties = new ContainerProperties(topic);
+    containerProperties.setGroupId(getGroupId(topic, operationName));
+    containerProperties.setAckOnError(false);
+    containerProperties.setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
+    containerProperties.setMessageListener(messageListener);
+    return containerProperties;
+  }
+
+  private String getGroupId(String topic, String operationName) {
+    return new StringJoiner("__")
+        .add(configProvider.getServiceName())
+        .add(topic)
+        .add(operationName)
+        .toString();
+  }
+
+}

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/DeserializerSupplier.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/DeserializerSupplier.java
@@ -1,0 +1,9 @@
+package ru.hh.nab.kafka.consumer;
+
+import org.apache.kafka.common.serialization.Deserializer;
+
+public interface DeserializerSupplier {
+
+  <T> Deserializer<T> supplyFor(Class<T> clazz);
+
+}

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/ListenStrategy.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/ListenStrategy.java
@@ -1,0 +1,9 @@
+package ru.hh.nab.kafka.consumer;
+
+import java.util.List;
+
+public interface ListenStrategy<T> {
+
+  void onMessagesBatch(List<T> messages, Ack ack);
+
+}

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/Listener.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/Listener.java
@@ -1,0 +1,7 @@
+package ru.hh.nab.kafka.consumer;
+
+public interface Listener {
+
+  void stopListen();
+
+}

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/ListenerFactory.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/ListenerFactory.java
@@ -1,0 +1,10 @@
+package ru.hh.nab.kafka.consumer;
+
+public interface ListenerFactory {
+
+  <T> Listener listenTopic(String topicName,
+                           String operationName,
+                           Class<T> messageClass,
+                           ListenStrategy<T> messageListener);
+
+}

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/serialization/JacksonDeserializerSupplier.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/serialization/JacksonDeserializerSupplier.java
@@ -1,0 +1,20 @@
+package ru.hh.nab.kafka.serialization;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import ru.hh.nab.kafka.consumer.DeserializerSupplier;
+
+public class JacksonDeserializerSupplier implements DeserializerSupplier {
+
+  private final ObjectMapper objectMapper;
+
+  public JacksonDeserializerSupplier(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public <T> Deserializer<T> supplyFor(Class<T> clazz) {
+    return new JsonDeserializer<>(clazz, objectMapper, false);
+  }
+}

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/util/ConfigProvider.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/util/ConfigProvider.java
@@ -24,6 +24,10 @@ public class ConfigProvider {
     this.fileSettings = fileSettings;
   }
 
+  public String getServiceName() {
+    return serviceName;
+  }
+
   public Map<String, Object> getConsumerConfig(String topicName) {
     Map<String, Object> consumeConfig = new HashMap<>();
     consumeConfig.put(ConsumerConfig.CLIENT_ID_CONFIG, serviceName);

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/util/ConfigProvider.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/util/ConfigProvider.java
@@ -1,0 +1,69 @@
+package ru.hh.nab.kafka.util;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import ru.hh.nab.common.properties.FileSettings;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ConfigProvider {
+
+  static final String COMMON_CONFIG_TEMPLATE = "%s.common";
+  static final String DEFAULT_CONSUMER_CONFIG_TEMPLATE = "%s.consumer.default";
+  static final String TOPIC_CONSUMER_CONFIG_TEMPLATE = "%s.consumer.topic.%s.default";
+  static final String DEFAULT_PRODUCER_CONFIG_TEMPLATE = "%s.producer.default";
+  static final String TOPIC_PRODUCER_CONFIG_TEMPLATE = "%s.producer.topic.%s.default";
+
+  private final String serviceName;
+  private final String kafkaClusterName;
+  private final FileSettings fileSettings;
+
+  public ConfigProvider(String serviceName, String kafkaClusterName, FileSettings fileSettings) {
+    this.serviceName = serviceName;
+    this.kafkaClusterName = kafkaClusterName;
+    this.fileSettings = fileSettings;
+  }
+
+  public Map<String, Object> getConsumerConfig(String topicName) {
+    Map<String, Object> consumeConfig = new HashMap<>();
+    consumeConfig.put(ConsumerConfig.CLIENT_ID_CONFIG, serviceName);
+    consumeConfig.putAll(getCommonProperties());
+    consumeConfig.putAll(getDefaultConsumerProperties());
+    consumeConfig.putAll(getTopicOverriddenConsumerProperties(topicName));
+    return consumeConfig;
+  }
+
+  private Map<String, Object> getDefaultConsumerProperties() {
+    return getConfigAsMap(String.format(DEFAULT_CONSUMER_CONFIG_TEMPLATE, kafkaClusterName));
+  }
+
+  private Map<String, Object> getTopicOverriddenConsumerProperties(String topicName) {
+    return getConfigAsMap(String.format(TOPIC_CONSUMER_CONFIG_TEMPLATE, kafkaClusterName, topicName));
+  }
+
+  public Map<String, Object> getProducerConfig(String topicName) {
+    Map<String, Object> producerConfig = new HashMap<>();
+    producerConfig.put(ProducerConfig.CLIENT_ID_CONFIG, serviceName);
+    producerConfig.putAll(getCommonProperties());
+    producerConfig.putAll(getDefaultProducerProperties());
+    producerConfig.putAll(getTopicOverriddenProducerProperties(topicName));
+    return producerConfig;
+  }
+
+  private Map<String, Object> getDefaultProducerProperties() {
+    return getConfigAsMap(String.format(DEFAULT_PRODUCER_CONFIG_TEMPLATE, kafkaClusterName));
+  }
+
+  private Map<String, Object> getTopicOverriddenProducerProperties(String topicName) {
+    return getConfigAsMap(String.format(TOPIC_PRODUCER_CONFIG_TEMPLATE, kafkaClusterName, topicName));
+  }
+
+  private Map<String, Object> getCommonProperties() {
+    return getConfigAsMap(String.format(COMMON_CONFIG_TEMPLATE, kafkaClusterName));
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> getConfigAsMap(String prefix) {
+    return new HashMap<>((Map) fileSettings.getSubProperties(prefix));
+  }
+}

--- a/nab-kafka/src/test/java/ru/hh/nab/kafka/util/ConfigProviderTest.java
+++ b/nab-kafka/src/test/java/ru/hh/nab/kafka/util/ConfigProviderTest.java
@@ -1,0 +1,123 @@
+package ru.hh.nab.kafka.util;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import ru.hh.nab.common.properties.FileSettings;
+import static ru.hh.nab.kafka.util.ConfigProvider.COMMON_CONFIG_TEMPLATE;
+import static ru.hh.nab.kafka.util.ConfigProvider.DEFAULT_CONSUMER_CONFIG_TEMPLATE;
+import static ru.hh.nab.kafka.util.ConfigProvider.DEFAULT_PRODUCER_CONFIG_TEMPLATE;
+import static ru.hh.nab.kafka.util.ConfigProvider.TOPIC_CONSUMER_CONFIG_TEMPLATE;
+import static ru.hh.nab.kafka.util.ConfigProvider.TOPIC_PRODUCER_CONFIG_TEMPLATE;
+import java.util.Map;
+import java.util.Properties;
+
+public class ConfigProviderTest {
+
+  private static final String SERVICE_NAME = "testService";
+  private static final String KAFKA_CLUSTER_NAME = "kafka";
+
+  @Test
+  public void shouldReturnCommonSettings() {
+    String testKey = "key";
+    String testValue = "value";
+    FileSettings fileSettings = createFileSettings(Map.of(
+        generateSettingKey(COMMON_CONFIG_TEMPLATE, testKey), testValue
+    ));
+
+    var result = createConfigProvider(fileSettings).getConsumerConfig("ignored");
+
+    assertEquals(testValue, result.get(testKey));
+  }
+
+  @Test
+  public void shouldContainServiceNameSetting() {
+    var result = createConfigProvider(createFileSettings(Map.of())).getConsumerConfig("ignored");
+
+    assertEquals(SERVICE_NAME, result.get(ConsumerConfig.CLIENT_ID_CONFIG));
+  }
+
+  @Test
+  public void shouldReturnConsumerDefaultSetting() {
+    String testKey = "key";
+    String testValue = "value";
+    FileSettings fileSettings = createFileSettings(Map.of(
+        generateSettingKey(DEFAULT_CONSUMER_CONFIG_TEMPLATE, testKey), testValue
+    ));
+
+    var result = createConfigProvider(fileSettings).getConsumerConfig("ignored");
+
+    assertEquals(testValue, result.get(testKey));
+  }
+
+  @Test
+  public void shouldReturnOverriddenConsumerSettingForSpecificTopic() {
+    String testKey = "key";
+    String defaultValue = "value";
+    String overriddenValue = "newValue";
+    String topicName = "topic";
+    FileSettings fileSettings = createFileSettings(Map.of(
+        generateSettingKey(DEFAULT_CONSUMER_CONFIG_TEMPLATE, testKey), defaultValue,
+        generateSettingKey(TOPIC_CONSUMER_CONFIG_TEMPLATE, topicName, testKey), overriddenValue
+    ));
+
+    ConfigProvider configProvider = createConfigProvider(fileSettings);
+
+    var result = configProvider.getConsumerConfig(topicName);
+    assertEquals(overriddenValue, result.get(testKey));
+
+    result = configProvider.getConsumerConfig("ignored");
+    assertEquals(defaultValue, result.get(testKey));
+  }
+
+  @Test
+  public void shouldReturnDefaultProducerSetting() {
+    String testKey = "key";
+    String testValue = "value";
+    FileSettings fileSettings = createFileSettings(Map.of(
+        generateSettingKey(DEFAULT_PRODUCER_CONFIG_TEMPLATE, testKey), testValue
+    ));
+
+    var result = createConfigProvider(fileSettings).getProducerConfig("ignored");
+
+    assertEquals(testValue, result.get(testKey));
+  }
+
+  @Test
+  public void shouldReturnOverriddenProducerSettingForSpecificTopic() {
+    String testKey = "key";
+    String defaultValue = "value";
+    String overriddenValue = "newValue";
+    String topicName = "topic";
+    FileSettings fileSettings = createFileSettings(Map.of(
+        generateSettingKey(DEFAULT_PRODUCER_CONFIG_TEMPLATE, testKey), defaultValue,
+        generateSettingKey(TOPIC_PRODUCER_CONFIG_TEMPLATE, topicName, testKey), overriddenValue
+    ));
+
+    ConfigProvider configProvider = createConfigProvider(fileSettings);
+
+    var result = configProvider.getProducerConfig(topicName);
+    assertEquals(overriddenValue, result.get(testKey));
+
+    result = configProvider.getProducerConfig("ignored");
+    assertEquals(defaultValue, result.get(testKey));
+  }
+
+  private static String generateSettingKey(String template, String testKey) {
+    return String.format(template, KAFKA_CLUSTER_NAME) + "." + testKey;
+  }
+
+  private static String generateSettingKey(String template, String topicName, String testKey) {
+    return String.format(template, KAFKA_CLUSTER_NAME, topicName) + "." + testKey;
+  }
+
+  private static ConfigProvider createConfigProvider(FileSettings fileSettings) {
+    return new ConfigProvider(SERVICE_NAME, KAFKA_CLUSTER_NAME, fileSettings);
+  }
+
+  private static FileSettings createFileSettings(Map<String, Object> props) {
+    Properties properties = new Properties();
+    properties.putAll(props);
+    return new FileSettings(properties);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <module>nab-logging</module>
         <module>nab-jclient</module>
         <module>nab-metrics</module>
+        <module>nab-kafka</module>
     </modules>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 
     <properties>
         <spring.version>5.2.2.RELEASE</spring.version>
+        <spring.kafka.version>2.3.4.RELEASE</spring.kafka.version>
         <jersey.version>2.29.1</jersey.version>
         <hibernate.version>5.2.10.Final</hibernate.version>
         <postgres.jdbc.version>42.2.5</postgres.jdbc.version>


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-101486

Начал работу над консюмером.
Решил остановится на нескольких основных интерфейсах:
1. ListenerFactory с методом listenTopic
2. Принимает в кач-ве аргумента ListenStrategy с методом `onMessagesBatch(List<T>, Ack)` 
3. Возвращает Listener, чтобы была возможность остановить контейнер (как в энричере)

Написал дефолтную реализацию ListenerFactory и попробовал ее в spam-detector https://github.com/hhru/spam-detector/pull/19/commits/e69e589e7d3ef2afa9f7f71ead7c2a434c373c53#diff-0a743696fa43b20b718495c6353de66cR79

Дальше решил продолжить в форме обсуждения, т.к. непросто предусмотреть все варианты.