### PR TITLE
HH-101492 add kafka publisher to module

### DIFF
--- a/nab-kafka/pom.xml
+++ b/nab-kafka/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>ru.hh.logging</groupId>
             <artifactId>timing-logger</artifactId>
-            <version>1.0</version>
+            <version>1.2.3</version>
         </dependency>
 
         <dependency>

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/monitoring/MonitoringListenStrategy.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/monitoring/MonitoringListenStrategy.java
@@ -22,7 +22,7 @@ public class MonitoringListenStrategy<T> implements ListenStrategy<T> {
 
   @Override
   public void onMessagesBatch(List<ConsumerRecord<String, T>> messages, Ack ack) {
-    timings.start();
+    timings.resetTime();
     listenStrategy.onMessagesBatch(messages, ack);
     timings.time();
   }
@@ -32,6 +32,6 @@ public class MonitoringListenStrategy<T> implements ListenStrategy<T> {
         .withMetric("batchProcessingTimeMs")
         .withStatsDSender(statsDSender);
     identifier.toMetricTags().forEach(builder::withTag);
-    return builder.build();
+    return builder.start();
   }
 }

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/publisher/Publisher.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/publisher/Publisher.java
@@ -1,0 +1,24 @@
+package ru.hh.nab.kafka.publisher;
+
+import java.util.concurrent.CompletableFuture;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+
+public class Publisher<T> {
+
+  private final String topic;
+  private final KafkaTemplate<String, T> kafkaTemplate;
+
+  public Publisher(String topic, KafkaTemplate<String, T> kafkaTemplate) {
+    this.topic = topic;
+    this.kafkaTemplate = kafkaTemplate;
+  }
+
+  public CompletableFuture<SendResult<String, T>> sendMessage(T kafkaMessage) {
+    return sendMessage(null, kafkaMessage);
+  }
+
+  public CompletableFuture<SendResult<String, T>> sendMessage(String key, T kafkaMessage) {
+    return kafkaTemplate.send(topic, key, kafkaMessage).completable();
+  }
+}

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/publisher/PublisherFactory.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/publisher/PublisherFactory.java
@@ -1,0 +1,34 @@
+package ru.hh.nab.kafka.publisher;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import ru.hh.kafka.monitoring.KafkaStatsDReporter;
+import ru.hh.nab.kafka.util.ConfigProvider;
+
+public class PublisherFactory {
+
+  private final ConfigProvider configProvider;
+  private final SerializerSupplier serializerSupplier;
+
+  public PublisherFactory(ConfigProvider configProvider,
+                          SerializerSupplier serializerSupplier) {
+    this.configProvider = configProvider;
+    this.serializerSupplier = serializerSupplier;
+  }
+
+  public <T> Publisher<T> createForTopic(String topicName) {
+    var producerConfig = configProvider.getProducerConfig(topicName);
+    producerConfig.put(CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG, KafkaStatsDReporter.class.getName());
+
+    ProducerFactory<String, T> producerFactory = new DefaultKafkaProducerFactory<>(
+        producerConfig,
+        new StringSerializer(),
+        serializerSupplier.supply()
+    );
+
+    return new Publisher<>(topicName, new KafkaTemplate<>(producerFactory));
+  }
+}

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/publisher/SerializerSupplier.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/publisher/SerializerSupplier.java
@@ -1,0 +1,8 @@
+package ru.hh.nab.kafka.publisher;
+
+import org.apache.kafka.common.serialization.Serializer;
+
+public interface SerializerSupplier {
+
+  <T> Serializer<T> supply();
+}

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/serialization/JacksonSerializerSupplier.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/serialization/JacksonSerializerSupplier.java
@@ -1,0 +1,21 @@
+package ru.hh.nab.kafka.serialization;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.common.serialization.Serializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import ru.hh.nab.kafka.publisher.SerializerSupplier;
+
+public class JacksonSerializerSupplier implements SerializerSupplier {
+
+  private final ObjectMapper objectMapper;
+
+  public JacksonSerializerSupplier(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public <T> Serializer<T> supply() {
+    JsonSerializer<T> serializer = new JsonSerializer<>(objectMapper);
+    serializer.setAddTypeInfo(false);
+    return serializer;
+  }
+}


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-101492

Добавил publisher.
Убрал `topicName` из `getProducerConfig()`, т.к., судя по другим сервисам, создается один кафка темлейт, и он используется для отсылки всех сообщений. 

Пример использования в спам детекторе https://github.com/hhru/spam-detector/pull/21