### PR TITLE
HH-105938 support X-HH-AcceptErrors header for custom exceptions

### DIFF
--- a/nab-starter/pom.xml
+++ b/nab-starter/pom.xml
@@ -210,6 +210,11 @@
             <version>3.1.6</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ru.hh.jclient-common</groupId>
+            <artifactId>jclient-common-api</artifactId>
+            <version>${jclient.version}</version>
+        </dependency>
 
     </dependencies>
 

--- a/nab-starter/src/main/java/ru/hh/nab/starter/filters/CommonHeadersFilter.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/filters/CommonHeadersFilter.java
@@ -10,6 +10,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import ru.hh.nab.starter.server.RequestHeaders;
 import static java.util.Optional.ofNullable;
+import static ru.hh.jclient.common.HttpHeaderNames.X_OUTER_TIMEOUT_MS;
 
 public final class CommonHeadersFilter extends OncePerRequestFilter {
 
@@ -20,7 +21,7 @@ public final class CommonHeadersFilter extends OncePerRequestFilter {
 
     var source = request.getHeader(RequestHeaders.REQUEST_SOURCE);
     var isLoadTesting = request.getHeader(RequestHeaders.LOAD_TESTING) != null;
-    var outerTimeoutMs = request.getHeader(RequestHeaders.OUTER_TIMEOUT_MS);
+    var outerTimeoutMs = request.getHeader(X_OUTER_TIMEOUT_MS);
 
     try {
       RequestContext.setRequestSource(source);

--- a/nab-starter/src/main/java/ru/hh/nab/starter/filters/ErrorAcceptFilter.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/filters/ErrorAcceptFilter.java
@@ -1,0 +1,43 @@
+package ru.hh.nab.starter.filters;
+
+import org.glassfish.jersey.message.internal.AcceptableMediaType;
+import org.glassfish.jersey.message.internal.HttpHeaderReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.List;
+
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static ru.hh.jclient.common.HttpHeaderNames.X_HH_ACCEPT_ERRORS;
+
+@Provider
+public class ErrorAcceptFilter implements ContainerResponseFilter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ErrorAcceptFilter.class);
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        if (responseContext.getStatus() >= 400) {
+            String acceptErrors = requestContext.getHeaders().getFirst(X_HH_ACCEPT_ERRORS);
+            if (acceptErrors != null) {
+                try {
+                    List<AcceptableMediaType> acceptableMediaTypes = HttpHeaderReader.readAcceptMediaType(acceptErrors);
+                    if (!acceptableMediaTypes.isEmpty()) {
+                        responseContext.getHeaders().replace(CONTENT_TYPE, List.of(acceptableMediaTypes.get(0).toString()));
+                    } else {
+                        LOGGER.warn("No valid AcceptableMediaType for errors found in {} header: {}",
+                            X_HH_ACCEPT_ERRORS,
+                            acceptErrors);
+                    }
+                } catch (ParseException e) {
+                    LOGGER.warn("Error while parcing {} header.", X_HH_ACCEPT_ERRORS, e);
+                }
+            }
+        }
+    }
+}

--- a/nab-starter/src/main/java/ru/hh/nab/starter/jersey/DefaultResourceConfig.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/jersey/DefaultResourceConfig.java
@@ -8,6 +8,7 @@ import ru.hh.nab.starter.exceptions.IllegalStateExceptionMapper;
 import ru.hh.nab.starter.exceptions.NotFoundExceptionMapper;
 import ru.hh.nab.starter.exceptions.SecurityExceptionMapper;
 import ru.hh.nab.starter.exceptions.WebApplicationExceptionMapper;
+import ru.hh.nab.starter.filters.ErrorAcceptFilter;
 import ru.hh.nab.starter.filters.ResourceNameLoggingFilter;
 
 import java.util.Collections;
@@ -25,6 +26,8 @@ public final class DefaultResourceConfig extends ResourceConfig {
     register(NotFoundExceptionMapper.class);
     register(SecurityExceptionMapper.class);
     register(WebApplicationExceptionMapper.class);
+
+    register(ErrorAcceptFilter.class);
 
     register(ResourceNameLoggingFilter.class);
   }

--- a/nab-starter/src/main/java/ru/hh/nab/starter/server/RequestHeaders.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/server/RequestHeaders.java
@@ -7,5 +7,4 @@ public final class RequestHeaders {
   public static final String EMPTY_REQUEST_ID = "noRequestId";
   public static final String REQUEST_SOURCE = "x-source";
   public static final String LOAD_TESTING = "x-load-testing";
-  public static final String OUTER_TIMEOUT_MS = "x-outer-timeout-ms";
 }

--- a/nab-starter/src/main/java/ru/hh/nab/starter/server/logging/StructuredRequestLogger.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/server/logging/StructuredRequestLogger.java
@@ -14,10 +14,10 @@ import static java.lang.System.currentTimeMillis;
 import static java.util.Optional.ofNullable;
 import static net.logstash.logback.marker.Markers.appendEntries;
 import static ru.hh.nab.starter.server.RequestHeaders.EMPTY_REQUEST_ID;
-import static ru.hh.nab.starter.server.RequestHeaders.OUTER_TIMEOUT_MS;
 import static ru.hh.nab.starter.server.RequestHeaders.REQUEST_ID;
 import static ru.hh.nab.starter.server.logging.RequestInfo.CACHE_ATTRIBUTE;
 import static ru.hh.nab.starter.server.logging.RequestInfo.NO_CACHE;
+import static ru.hh.jclient.common.HttpHeaderNames.X_OUTER_TIMEOUT_MS;
 
 public class StructuredRequestLogger extends AbstractLifeCycle implements RequestLog {
   private static final Logger LOGGER = LoggerFactory.getLogger(StructuredRequestLogger.class);
@@ -25,7 +25,7 @@ public class StructuredRequestLogger extends AbstractLifeCycle implements Reques
 
   @Override
   public void log(Request request, Response response) {
-    final String outerTimoutMs = request.getHeader(OUTER_TIMEOUT_MS);
+    final String outerTimoutMs = request.getHeader(X_OUTER_TIMEOUT_MS);
     final String requestId = request.getHeader(REQUEST_ID);
     final String cache = (String) request.getAttribute(CACHE_ATTRIBUTE);
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <jackson.version>2.10.0</jackson.version>
         <slf4j.version>1.7.28</slf4j.version>
         <logback.version>1.2.3</logback.version>
-        <jclient.version>1.6.3</jclient.version>
+        <jclient.version>1.7.5</jclient.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>11</java.version>
     </properties>


### PR DESCRIPTION
Идея в том, чтобы всегда иметь возможность регулировать медиа тайп в котором должны прилетать ошибки для того, чтобы их правильно десериализовать. 
К сожалению, ошибки джерси формируются уже почле выполнения всех фильтров и для них медиатайп сбрасывается и устанавливается заново, исходя именно из Accept хэдера. 
С другой стороны джерсёвая ошибка, прилетевшая даже в правильном формате, всё равно не десериализуется в нужный нам класс ошибки, так что, возможно, этим можно пренебречь. 