### PR TITLE
HH-107814 return Acknowledgment for kafka batch messages

### DIFF
--- a/nab-common/pom.xml
+++ b/nab-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.23.3-SNAPSHOT</version>
+        <version>4.23.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/nab-common/pom.xml
+++ b/nab-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.23.3</version>
+        <version>4.23.4-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/nab-common/src/main/java/ru/hh/nab/common/properties/FileSettings.java
+++ b/nab-common/src/main/java/ru/hh/nab/common/properties/FileSettings.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import static java.util.Arrays.asList;
 import java.util.List;
 import java.util.Properties;
+import java.util.function.Function;
 import static org.springframework.util.Assert.hasLength;
 
 public class FileSettings {
@@ -17,19 +18,36 @@ public class FileSettings {
     return properties.getProperty(key);
   }
 
+  public int getInteger(String key, int defaultValue) {
+    return parseValueOrDefault(key, Integer::parseInt, defaultValue);
+  }
+
   public Integer getInteger(String key) {
-    String value = getString(key);
-    return value != null ? Integer.parseInt(value): null;
+    return parseValueOrDefault(key, Integer::parseInt, null);
+  }
+
+  public long getLong(final String key, long defaultValue) {
+    return parseValueOrDefault(key, Long::parseLong, defaultValue);
   }
 
   public Long getLong(final String key) {
-    String value = getString(key);
-    return value != null ? Long.parseLong(value): null;
+    return parseValueOrDefault(key, Long::parseLong, null);
+  }
+
+  public double getDouble(final String key, double defaultValue) {
+    return parseValueOrDefault(key, Double::parseDouble, defaultValue);
+  }
+
+  public Double getDouble(final String key) {
+    return parseValueOrDefault(key, Double::parseDouble, null);
+  }
+
+  public boolean getBoolean(String key, boolean defaultValue) {
+    return parseValueOrDefault(key, Boolean::parseBoolean, defaultValue);
   }
 
   public Boolean getBoolean(String key) {
-    String value = getString(key);
-    return value != null ? Boolean.parseBoolean(value): null;
+    return parseValueOrDefault(key, Boolean::parseBoolean, null);
   }
 
   public Properties getSubProperties(String prefix) {
@@ -57,5 +75,10 @@ public class FileSettings {
     Properties propertiesCopy = new Properties();
     propertiesCopy.putAll(this.properties);
     return propertiesCopy;
+  }
+
+  private <R> R parseValueOrDefault(String key, Function<String, R> function, R defaultValue) {
+    String value = getString(key);
+    return value == null ? defaultValue : function.apply(value);
   }
 }

--- a/nab-data-source/pom.xml
+++ b/nab-data-source/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.23.3-SNAPSHOT</version>
+        <version>4.23.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/nab-data-source/pom.xml
+++ b/nab-data-source/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.23.3</version>
+        <version>4.23.4-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/nab-example/pom.xml
+++ b/nab-example/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.23.3-SNAPSHOT</version>
+        <version>4.23.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/nab-example/pom.xml
+++ b/nab-example/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.23.3</version>
+        <version>4.23.4-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/nab-hibernate/pom.xml
+++ b/nab-hibernate/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.23.3-SNAPSHOT</version>
+        <version>4.23.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/nab-hibernate/pom.xml
+++ b/nab-hibernate/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.23.3</version>
+        <version>4.23.4-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/nab-jclient/pom.xml
+++ b/nab-jclient/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.23.3-SNAPSHOT</version>
+        <version>4.23.3</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-jclient/pom.xml
+++ b/nab-jclient/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.23.3</version>
+        <version>4.23.4-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-kafka/pom.xml
+++ b/nab-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>nuts-and-bolts-parent</artifactId>
         <groupId>ru.hh.nab</groupId>
-        <version>4.23.3-SNAPSHOT</version>
+        <version>4.23.3</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-kafka/pom.xml
+++ b/nab-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>nuts-and-bolts-parent</artifactId>
         <groupId>ru.hh.nab</groupId>
-        <version>4.23.3</version>
+        <version>4.23.4-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/Ack.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/Ack.java
@@ -1,7 +1,26 @@
 package ru.hh.nab.kafka.consumer;
 
 public interface Ack {
-
+  /**
+   * Invoked when the record or batch for which the acknowledgment has been created has
+   * been processed. Calling this method implies that all the previous messages in the
+   * partition have been processed already.
+   */
   void acknowledge();
 
+  /**
+   * Negatively acknowledge the record at an index in a batch - commit the offset(s) of
+   * records before the index and re-seek the partitions so that the record at the index
+   * and subsequent records will be redelivered after the sleep time. Must be called on
+   * the consumer thread.
+   * <p>
+   * <b>When using group management,
+   * {@code sleep + time spent processing the records before the index} must be less
+   * than the consumer {@code max.poll.interval.ms} property, to avoid a rebalance.</b>
+   *
+   * @param index the index of the failed record in the batch.
+   * @param sleepMs the time to sleep.
+   * @since 2.3
+   */
+  void nack(int index, long sleepMs);
 }

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/util/ConfigProvider.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/util/ConfigProvider.java
@@ -1,18 +1,27 @@
 package ru.hh.nab.kafka.util;
 
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import ru.hh.nab.common.properties.FileSettings;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import ru.hh.nab.common.properties.FileSettings;
 
 public class ConfigProvider {
-
   static final String COMMON_CONFIG_TEMPLATE = "%s.common";
   static final String DEFAULT_CONSUMER_CONFIG_TEMPLATE = "%s.consumer.default";
   static final String TOPIC_CONSUMER_CONFIG_TEMPLATE = "%s.consumer.topic.%s.default";
   static final String PRODUCER_CONFIG_TEMPLATE = "%s.producer.%s";
+  static final String NAB_SETTING = "nab_setting";
   public static final String DEFAULT_PRODUCER_NAME = "default";
+
+  public static final String BACKOFF_INITIAL_INTERVAL_NAME = "backoff.initial.interval";
+  public static final long DEFAULT_BACKOFF_INITIAL_INTERVAL = 1000L;
+  public static final String BACKOFF_MAX_INTERVAL_NAME = "backoff.max.interval";
+  public static final long DEFAULT_BACKOFF_MAX_INTERVAL = 60000L;
+  public static final String BACKOFF_MULTIPLIER_NAME = "backoff.multiplier";
+  public static final double DEFAULT_BACKOFF_MULTIPLIER = 1.5;
 
   private final String serviceName;
   private final String kafkaClusterName;
@@ -34,7 +43,29 @@ public class ConfigProvider {
     consumeConfig.putAll(getCommonProperties());
     consumeConfig.putAll(getDefaultConsumerProperties());
     consumeConfig.putAll(getTopicOverriddenConsumerProperties(topicName));
+    removeNabProperties(consumeConfig);
     return consumeConfig;
+  }
+
+  public FileSettings getNabConsumerSettings(String topicName) {
+    Properties allProperties = new Properties();
+    allProperties.putAll(getCommonProperties());
+    allProperties.putAll(getDefaultConsumerProperties());
+    allProperties.putAll(getTopicOverriddenConsumerProperties(topicName));
+    removeNonNabProperties(allProperties);
+    FileSettings fileSettings = new FileSettings(allProperties);
+    checkConfig(fileSettings);
+    return fileSettings;
+  }
+
+  private void checkConfig(FileSettings settings) {
+    long maxPollMs = settings.getLong(MAX_POLL_INTERVAL_MS_CONFIG, 300000L);
+    long backoffMaxInterval = settings.getLong(BACKOFF_MAX_INTERVAL_NAME, DEFAULT_BACKOFF_MAX_INTERVAL);
+    if (backoffMaxInterval > maxPollMs) {
+      throw new IllegalArgumentException(
+          String.format("'%s' should not be larger then '%s'", BACKOFF_MAX_INTERVAL_NAME, MAX_POLL_INTERVAL_MS_CONFIG)
+      );
+    }
   }
 
   private Map<String, Object> getDefaultConsumerProperties() {
@@ -68,5 +99,21 @@ public class ConfigProvider {
   @SuppressWarnings("unchecked")
   private Map<String, Object> getConfigAsMap(String prefix) {
     return new HashMap<>((Map) fileSettings.getSubProperties(prefix));
+  }
+
+  private void removeNabProperties(Map<String, Object> config) {
+    for (String key : config.keySet()) {
+      if (key.contains(NAB_SETTING)) {
+        config.remove(key);
+      }
+    }
+  }
+
+  private void removeNonNabProperties(Properties allProperties) {
+    for (Object key : allProperties.keySet()) {
+      if (!((String)key).contains(NAB_SETTING)) {
+        allProperties.remove(key);
+      }
+    }
   }
 }

--- a/nab-logging/pom.xml
+++ b/nab-logging/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.23.3-SNAPSHOT</version>
+        <version>4.23.3</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-logging/pom.xml
+++ b/nab-logging/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.23.3</version>
+        <version>4.23.4-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-metrics/pom.xml
+++ b/nab-metrics/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.23.3-SNAPSHOT</version>
+        <version>4.23.3</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-metrics/pom.xml
+++ b/nab-metrics/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.23.3</version>
+        <version>4.23.4-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-starter/pom.xml
+++ b/nab-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.23.3-SNAPSHOT</version>
+        <version>4.23.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/nab-starter/pom.xml
+++ b/nab-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.23.3</version>
+        <version>4.23.4-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/nab-testbase/pom.xml
+++ b/nab-testbase/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.23.3-SNAPSHOT</version>
+        <version>4.23.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/nab-testbase/pom.xml
+++ b/nab-testbase/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.23.3</version>
+        <version>4.23.4-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/nab-tests/pom.xml
+++ b/nab-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.23.3-SNAPSHOT</version>
+        <version>4.23.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/nab-tests/pom.xml
+++ b/nab-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.23.3</version>
+        <version>4.23.4-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>ru.hh.nab</groupId>
     <artifactId>nuts-and-bolts-parent</artifactId>
     <packaging>pom</packaging>
-    <version>4.23.3</version>
+    <version>4.23.4-SNAPSHOT</version>
 
     <name>nuts'n'bolts parent module</name>
 
@@ -229,6 +229,6 @@
     <scm>
         <connection>scm:git:git@github.com:hhru/nuts-and-bolts.git</connection>
         <developerConnection>scm:git:git@github.com:hhru/nuts-and-bolts.git</developerConnection>
-        <tag>nuts-and-bolts-parent-4.23.3</tag>
+        <tag>HEAD</tag>
     </scm>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <spring.version>5.2.2.RELEASE</spring.version>
-        <spring.kafka.version>2.3.4.RELEASE</spring.kafka.version>
+        <spring.kafka.version>2.3.7.RELEASE</spring.kafka.version>
         <jersey.version>2.29.1</jersey.version>
         <hibernate.version>5.2.10.Final</hibernate.version>
         <postgres.jdbc.version>42.2.5</postgres.jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>ru.hh.nab</groupId>
     <artifactId>nuts-and-bolts-parent</artifactId>
     <packaging>pom</packaging>
-    <version>4.23.3-SNAPSHOT</version>
+    <version>4.23.3</version>
 
     <name>nuts'n'bolts parent module</name>
 
@@ -229,6 +229,6 @@
     <scm>
         <connection>scm:git:git@github.com:hhru/nuts-and-bolts.git</connection>
         <developerConnection>scm:git:git@github.com:hhru/nuts-and-bolts.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>nuts-and-bolts-parent-4.23.3</tag>
     </scm>
 </project>


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-107814

Из-за того что решили использовать свой Ack вместо спрингового Acknowledgment пропала возможность использовать методы nack которые удобно использовать для перемотки к упавшему сообщению в батче и не дублировать обработанные сообщения.
https://github.com/spring-projects/spring-kafka/blob/master/spring-kafka/src/main/java/org/springframework/kafka/support/Acknowledgment.java#L66 

Да и не совсем понятно какую цель приследовали со своим интерфейсом.