### PR TITLE
HH-109743 remove default value from ExecuteOnDataSource.dataSourceType

### DIFF
--- a/nab-example/pom.xml
+++ b/nab-example/pom.xml
@@ -52,6 +52,13 @@
             </plugin>
 
             <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <skipSource>true</skipSource>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-install-plugin</artifactId>
                 <configuration>

--- a/nab-hibernate/src/main/java/ru/hh/nab/hibernate/transaction/ExecuteOnDataSource.java
+++ b/nab-hibernate/src/main/java/ru/hh/nab/hibernate/transaction/ExecuteOnDataSource.java
@@ -17,7 +17,10 @@ public @interface ExecuteOnDataSource {
 
   boolean writableTx() default false;
 
-  String dataSourceType() default DataSourceType.READONLY;
+  /**
+   * see {@link DataSourceType} for common datasource types
+   */
+  String dataSourceType();
 
   boolean overrideByRequestScope() default false;
 

--- a/nab-hibernate/src/test/java/ru/hh/nab/hibernate/NabSessionFactoryBuilderFactoryTest.java
+++ b/nab-hibernate/src/test/java/ru/hh/nab/hibernate/NabSessionFactoryBuilderFactoryTest.java
@@ -32,6 +32,7 @@ import org.springframework.orm.hibernate5.HibernateTransactionManager;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+import ru.hh.nab.datasource.DataSourceType;
 import ru.hh.nab.hibernate.transaction.DataSourceContextTransactionManager;
 import ru.hh.nab.hibernate.transaction.ExecuteOnDataSource;
 import ru.hh.nab.hibernate.transaction.TransactionalScope;
@@ -72,7 +73,7 @@ public class NabSessionFactoryBuilderFactoryTest {
       this.transactionalScope = transactionalScope;
     }
 
-    @ExecuteOnDataSource
+    @ExecuteOnDataSource(dataSourceType = DataSourceType.READONLY)
     public void method() throws SQLException {
       AtomicReference<Connection> ref = new AtomicReference<>();
       transactionalScope.read(() -> {
@@ -127,7 +128,7 @@ public class NabSessionFactoryBuilderFactoryTest {
     }
 
     @Bean
-    NabSessionFactoryBean sessionFactoryBean(DataSource dataSource, NabSessionFactoryBean.ServiceSupplier supplier) throws IOException {
+    NabSessionFactoryBean sessionFactoryBean(DataSource dataSource, NabSessionFactoryBean.ServiceSupplier<?> supplier) throws IOException {
       var props = new Properties();
       props.load(TestContext.class.getResourceAsStream("/hibernate-test.properties"));
       return new NabSessionFactoryBean(dataSource, props,

--- a/nab-starter/src/test/java/ru/hh/nab/starter/server/jetty/HHServerConnectorFailFastTest.java
+++ b/nab-starter/src/test/java/ru/hh/nab/starter/server/jetty/HHServerConnectorFailFastTest.java
@@ -96,13 +96,16 @@ public class HHServerConnectorFailFastTest {
     List<Future<Integer>> statusesFutures = new ArrayList<>(REQUESTS);
 
     for (int i=0; i < REQUESTS; i++) {
+      if (i == REQUESTS - 1) {
+        // make sure at least one request is made AFTER low on threads
+        await().atMost(500, TimeUnit.MILLISECONDS).until(threadPool::isLowOnThreads);
+      }
+
       Socket socket = new Socket("localhost", serverPort);
       sockets.add(socket);
       Future<Integer> statusFuture = httpClient.request(socket);
       statusesFutures.add(statusFuture);
     }
-
-    await().atMost(500, TimeUnit.MILLISECONDS).until(threadPool::isLowOnThreads);
 
     controlledServlet.respond();
 

--- a/nab-testbase-old/src/main/resources/service-test.properties
+++ b/nab-testbase-old/src/main/resources/service-test.properties
@@ -11,7 +11,7 @@ kafka.producer.default.batch.size=1
 
 kafka.consumer.default.auto.offset.reset=earliest
 kafka.consumer.default.fetch.max.wait.ms=250
-kafka.consumer.default.max.poll.interval.ms=500
+kafka.consumer.default.max.poll.interval.ms=5000
 kafka.consumer.default.max.poll.records=25
 kafka.consumer.default.nab_setting.pool.timeout.ms=500
 kafka.consumer.default.nab_setting.backoff.initial.interval=1

--- a/nab-testbase/src/main/resources/service-test.properties
+++ b/nab-testbase/src/main/resources/service-test.properties
@@ -11,7 +11,7 @@ kafka.producer.default.batch.size=1
 
 kafka.consumer.default.auto.offset.reset=earliest
 kafka.consumer.default.fetch.max.wait.ms=250
-kafka.consumer.default.max.poll.interval.ms=500
+kafka.consumer.default.max.poll.interval.ms=5000
 kafka.consumer.default.max.poll.records=25
 kafka.consumer.default.nab_setting.pool.timeout.ms=500
 kafka.consumer.default.nab_setting.backoff.initial.interval=1

--- a/nab-tests/pom.xml
+++ b/nab-tests/pom.xml
@@ -110,6 +110,18 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <skipSource>true</skipSource>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-install-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>

--- a/nab-tests/src/test/java/ru/hh/nab/datasource/ExecuteOnDataSourceAspectTest.java
+++ b/nab-tests/src/test/java/ru/hh/nab/datasource/ExecuteOnDataSourceAspectTest.java
@@ -167,11 +167,6 @@ public class ExecuteOnDataSourceAspectTest extends HibernateTestBase {
       this.sessionFactory = sessionFactory;
     }
 
-    @ExecuteOnDataSource(dataSourceType = WRITABLE_DATASOURCE)
-    public void customReadOnly() {
-
-    }
-
     @Transactional
     @ExecuteOnDataSource(dataSourceType = WRITABLE_DATASOURCE, writableTx = true)
     public void customWrite() {

--- a/nab-tests/src/test/java/ru/hh/nab/kafka/consumer/ConsumerRecoveryAfterFailTest.java
+++ b/nab-tests/src/test/java/ru/hh/nab/kafka/consumer/ConsumerRecoveryAfterFailTest.java
@@ -141,7 +141,7 @@ public class ConsumerRecoveryAfterFailTest extends KafkaConsumerTestbase {
       });
       ack.acknowledge();
     });
-    fails.await(3, TimeUnit.SECONDS);
+    assertTrue(fails.await(15, TimeUnit.SECONDS));
     stopConsumer();
 
     putMessagesIntoKafka(17);
@@ -171,7 +171,7 @@ public class ConsumerRecoveryAfterFailTest extends KafkaConsumerTestbase {
         ack.acknowledge(m);
       });
     });
-    fails.await(3, TimeUnit.SECONDS);
+    assertTrue(fails.await(15, TimeUnit.SECONDS));
     stopConsumer();
 
     putMessagesIntoKafka(17);
@@ -203,7 +203,7 @@ public class ConsumerRecoveryAfterFailTest extends KafkaConsumerTestbase {
   }
 
   private void waitUntil(Runnable assertion) throws InterruptedException {
-    await().atMost(3, TimeUnit.SECONDS).untilAsserted(assertion::run);
+    await().atMost(15, TimeUnit.SECONDS).untilAsserted(assertion::run);
     stopConsumer();
   }
 
@@ -218,7 +218,7 @@ public class ConsumerRecoveryAfterFailTest extends KafkaConsumerTestbase {
   private void stopConsumer() throws InterruptedException {
     CountDownLatch latch = new CountDownLatch(1);
     consumer.stop(latch::countDown);
-    latch.await(2, TimeUnit.SECONDS);
+    assertTrue(latch.await(5, TimeUnit.SECONDS));
   }
 
   private Map<String, Long> getProcessedMessagesCount() {


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-109743

Убрал дефолтный тип датасорса из `@ExecuteOnDataSource`.
Заодно поправил некоторые нестабильные тесты, ну и по мелочи.