### PR TITLE
HH-115873 change structure of datasource metrics

### DIFF
--- a/nab-data-source/src/main/java/ru/hh/nab/datasource/monitoring/ConnectionPoolMetrics.java
+++ b/nab-data-source/src/main/java/ru/hh/nab/datasource/monitoring/ConnectionPoolMetrics.java
@@ -1,19 +1,20 @@
 package ru.hh.nab.datasource.monitoring;
 
 public final class ConnectionPoolMetrics {
-  public static final String CREATION_MS = "connection.creation_ms";
-  public static final String ACQUISITION_MS = "connection.acquisition_ms";
-  public static final String USAGE_MS = "connection.usage_ms";
-  public static final String TOTAL_USAGE_MS = "connection.total_usage_ms";
-  public static final String SAMPLED_USAGE_MS = "connection.sampled_usage_ms";
+  public static final String CREATION_MS = "jdbc_pool.connection.creation_ms";
+  public static final String ACQUISITION_MS = "jdbc_pool.connection.acquisition_ms";
+  public static final String USAGE_MS = "jdbc_pool.connection.usage_ms";
+  public static final String TOTAL_USAGE_MS = "jdbc_pool.connection.total_usage_ms";
+  public static final String SAMPLED_USAGE_MS = "jdbc_pool.connection.sampled_usage_ms";
 
-  public static final String CONNECTION_TIMEOUTS = "pool.connection_timeouts";
-  public static final String ACTIVE_CONNECTIONS = "pool.active_connections";
-  public static final String TOTAL_CONNECTIONS = "pool.total_connections";
-  public static final String IDLE_CONNECTIONS = "pool.idle_connections";
-  public static final String MAX_CONNECTIONS = "pool.max_connections";
-  public static final String MIN_CONNECTIONS = "pool.min_connections";
-  public static final String PENDING_THREADS = "pool.pending_threads";
+  public static final String CONNECTION_TIMEOUTS = "jdbc_pool.connection_timeouts";
+  public static final String ACTIVE_CONNECTIONS = "jdbc_pool.active_connections";
+  public static final String TOTAL_CONNECTIONS = "jdbc_pool.total_connections";
+  public static final String IDLE_CONNECTIONS = "jdbc_pool.idle_connections";
+  public static final String MAX_CONNECTIONS = "jdbc_pool.max_connections";
+  public static final String MIN_CONNECTIONS = "jdbc_pool.min_connections";
+  public static final String PENDING_THREADS = "jdbc_pool.pending_threads";
+
 
   private ConnectionPoolMetrics() {
   }

--- a/nab-metrics/src/main/java/ru/hh/nab/metrics/StatsDSender.java
+++ b/nab-metrics/src/main/java/ru/hh/nab/metrics/StatsDSender.java
@@ -48,6 +48,10 @@ public class StatsDSender {
     computeAndSendPercentiles(metricName, null, histogram.getValueToCountAndReset(), percentiles);
   }
 
+  public void sendHistogram(String metricName, Tag[] tags, Histogram histogram, int... percentiles) {
+    computeAndSendPercentiles(metricName, tags, histogram.getValueToCountAndReset(), percentiles);
+  }
+
   public void sendHistograms(String metricName, Histograms histograms, int... percentiles) {
     Map<Tags, Map<Integer, Integer>> tagsToHistogram = histograms.getTagsToHistogramAndReset();
     for (Map.Entry<Tags, Map<Integer, Integer>> tagsAndHistogram : tagsToHistogram.entrySet()) {


### PR DESCRIPTION
Изменена структура метрик БД

Было: name="hh-as.slow.connection.creation_ms"
Стало: name="jdbc_pool.connection.creation_ms", datasource="slow", app="hh-as"

Имя метрики унифицировано, а индивидуальные части каждого сервиса или БД вынесены в соответствующие тэги
Метрики старого формата передаваться не будут
