### PR TITLE
HH-127022 remove misleading 'Ms' from metric name

### DIFF
--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/monitoring/MonitoringConsumeStrategy.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/monitoring/MonitoringConsumeStrategy.java
@@ -46,7 +46,7 @@ public class MonitoringConsumeStrategy<T> implements ConsumeStrategy<T> {
 
   private Timings buildTimings(StatsDSender statsDSender, ConsumerGroupId identifier) {
     Timings.Builder builder = new Timings.Builder()
-        .withMetric("batchProcessingTimeMs")
+        .withMetric("batchProcessingTime")
         .withStatsDSender(statsDSender);
     identifier.toMetricTags().forEach(builder::withTag);
     return builder.start();

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.public-pom</groupId>
         <artifactId>public-pom</artifactId>
-        <version>1.47</version>
+        <version>1.48</version>
     </parent>
 
     <groupId>ru.hh.nab</groupId>


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-127022

Поскольку метрика "batchProcessingTimeMs" имеет тип "timer", окметр понимает, что это время, и автоматически рисует её в секундах, и суффикс "Ms" оказывается лишним.