### PR TITLE
HH-127070 fix naming: 'pool' -> 'poll'

### DIFF
--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/DefaultConsumerFactory.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/DefaultConsumerFactory.java
@@ -27,8 +27,8 @@ import static ru.hh.nab.kafka.util.ConfigProvider.DEFAULT_AUTH_EXCEPTION_RETRY_I
 import static ru.hh.nab.kafka.util.ConfigProvider.DEFAULT_BACKOFF_INITIAL_INTERVAL;
 import static ru.hh.nab.kafka.util.ConfigProvider.DEFAULT_BACKOFF_MAX_INTERVAL;
 import static ru.hh.nab.kafka.util.ConfigProvider.DEFAULT_BACKOFF_MULTIPLIER;
-import static ru.hh.nab.kafka.util.ConfigProvider.DEFAULT_POOL_TIMEOUT_MS;
-import static ru.hh.nab.kafka.util.ConfigProvider.POOL_TIMEOUT;
+import static ru.hh.nab.kafka.util.ConfigProvider.DEFAULT_POLL_TIMEOUT_MS;
+import static ru.hh.nab.kafka.util.ConfigProvider.POLL_TIMEOUT;
 import ru.hh.nab.metrics.StatsDSender;
 
 public class DefaultConsumerFactory implements KafkaConsumerFactory {
@@ -134,7 +134,7 @@ public class DefaultConsumerFactory implements KafkaConsumerFactory {
     containerProperties.setAckOnError(false);
     containerProperties.setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
     containerProperties.setMessageListener(messageListener);
-    containerProperties.setPollTimeout(nabConsumerSettings.getLong(POOL_TIMEOUT, DEFAULT_POOL_TIMEOUT_MS));
+    containerProperties.setPollTimeout(nabConsumerSettings.getLong(POLL_TIMEOUT, DEFAULT_POLL_TIMEOUT_MS));
     containerProperties.setAuthorizationExceptionRetryInterval(
         Duration.ofMillis(nabConsumerSettings.getLong(AUTH_EXCEPTION_RETRY_INTERVAL, DEFAULT_AUTH_EXCEPTION_RETRY_INTERVAL_MS)));
     return containerProperties;

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/util/ConfigProvider.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/util/ConfigProvider.java
@@ -32,8 +32,8 @@ public class ConfigProvider {
   public static final String BACKOFF_MULTIPLIER_NAME = "backoff.multiplier";
   public static final double DEFAULT_BACKOFF_MULTIPLIER = 1.5;
 
-  public static final String POOL_TIMEOUT = "pool.timeout.ms";
-  public static final long DEFAULT_POOL_TIMEOUT_MS = 5000L;
+  public static final String POLL_TIMEOUT = "poll.timeout.ms";
+  public static final long DEFAULT_POLL_TIMEOUT_MS = 5000L;
 
   public static final String AUTH_EXCEPTION_RETRY_INTERVAL = "auth.exception.retry.interval.ms";
   public static final long DEFAULT_AUTH_EXCEPTION_RETRY_INTERVAL_MS = 10000L;

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/util/ConfigProvider.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/util/ConfigProvider.java
@@ -21,8 +21,8 @@ public class ConfigProvider {
   static final String TOPIC_CONSUMER_INVALID_CONFIG_REGEXP_TEMPLATE =
       "%s\\.consumer\\.topic\\.%s\\.(?!\\w*(?:default)).*";
   static final String PRODUCER_CONFIG_TEMPLATE = "%s.producer.%s";
-  static final String NAB_SETTING = "nab_setting";
-  static final Predicate<Object> NAB_SETTING_PREDICATE = key -> ((String) key).contains(NAB_SETTING);
+  public static final String NAB_SETTING = "nab_setting";
+  static final Predicate<Object> NAB_SETTING_PREDICATE = key -> ((String) key).startsWith(NAB_SETTING + ".");
   public static final String DEFAULT_PRODUCER_NAME = "default";
 
   public static final String BACKOFF_INITIAL_INTERVAL_NAME = "backoff.initial.interval";
@@ -68,11 +68,12 @@ public class ConfigProvider {
     removeNonNabProperties(nabProperties);
     FileSettings nabConsumerSettings = new FileSettings(nabProperties).getSubSettings(NAB_SETTING);
 
-    Properties allProperties = new Properties();
-    allProperties.putAll(allConsumerConfigs);
-    FileSettings allConsumerSettings = new FileSettings(allProperties);
+    Properties nonNabProperties = new Properties();
+    nonNabProperties.putAll(allConsumerConfigs);
+    removeNabProperties(nonNabProperties);
+    FileSettings nonNabConsumerSettings = new FileSettings(nonNabProperties);
 
-    checkConfig(nabConsumerSettings, allConsumerSettings);
+    checkConfig(nabConsumerSettings, nonNabConsumerSettings);
     return nabConsumerSettings;
   }
 
@@ -84,22 +85,21 @@ public class ConfigProvider {
     return consumerConfig;
   }
 
-  private void checkConfig(FileSettings nabConsumerSettings, FileSettings allConsumerSettings) {
-    long maxPollMs = allConsumerSettings.getLong(MAX_POLL_INTERVAL_MS_CONFIG, 300000L);
+  private void checkConfig(FileSettings nabConsumerSettings, FileSettings nonNabConsumerSettings) {
+    long maxPollMs = nonNabConsumerSettings.getLong(MAX_POLL_INTERVAL_MS_CONFIG, 300000L);
     long backoffMaxInterval = nabConsumerSettings.getLong(BACKOFF_MAX_INTERVAL_NAME, DEFAULT_BACKOFF_MAX_INTERVAL);
     if (backoffMaxInterval > maxPollMs) {
       throw new IllegalArgumentException(
           String.format("'%s' should not be larger then '%s'", BACKOFF_MAX_INTERVAL_NAME, MAX_POLL_INTERVAL_MS_CONFIG)
       );
     }
-    checkNames(allConsumerSettings);
+    checkNames(nonNabConsumerSettings);
   }
 
-  private static void checkNames(FileSettings allConsumerSettings) {
+  private static void checkNames(FileSettings nonNabConsumerSettings) {
     Set<String> supportedNames = ConsumerConfig.configNames();
-    List<String> invalidNames = allConsumerSettings.getProperties().keySet()
+    List<String> invalidNames = nonNabConsumerSettings.getProperties().keySet()
         .stream()
-        .filter(NAB_SETTING_PREDICATE.negate())
         .filter(key -> !supportedNames.contains(key))
         .map(String::valueOf)
         .collect(Collectors.toList());
@@ -161,7 +161,7 @@ public class ConfigProvider {
     return new HashMap<>((Map) fileSettings.getSubProperties(prefix));
   }
 
-  private void removeNabProperties(Map<String, Object> config) {
+  private void removeNabProperties(Map<?, ?> config) {
     config.keySet().removeIf(NAB_SETTING_PREDICATE);
   }
 

--- a/nab-testbase-old/src/main/resources/service-test.properties
+++ b/nab-testbase-old/src/main/resources/service-test.properties
@@ -14,7 +14,7 @@ kafka.consumer.default.auto.offset.reset=earliest
 kafka.consumer.default.fetch.max.wait.ms=250
 kafka.consumer.default.max.poll.interval.ms=5000
 kafka.consumer.default.max.poll.records=25
-kafka.consumer.default.nab_setting.pool.timeout.ms=500
+kafka.consumer.default.nab_setting.poll.timeout.ms=500
 kafka.consumer.default.nab_setting.backoff.initial.interval=1
 kafka.consumer.default.nab_setting.backoff.max.interval=1
 

--- a/nab-testbase/src/main/resources/service-test.properties
+++ b/nab-testbase/src/main/resources/service-test.properties
@@ -15,7 +15,7 @@ kafka.consumer.default.auto.offset.reset=earliest
 kafka.consumer.default.fetch.max.wait.ms=250
 kafka.consumer.default.max.poll.interval.ms=5000
 kafka.consumer.default.max.poll.records=25
-kafka.consumer.default.nab_setting.pool.timeout.ms=500
+kafka.consumer.default.nab_setting.poll.timeout.ms=500
 kafka.consumer.default.nab_setting.backoff.initial.interval=1
 kafka.consumer.default.nab_setting.backoff.max.interval=1
 


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-127070

Пофиксил неправильные именования. И сделал построже проверку кафка-настроек.