### PR TITLE
HH-139715 no need to explicitly stop cache

### DIFF
--- a/nab-starter/pom.xml
+++ b/nab-starter/pom.xml
@@ -170,8 +170,8 @@
         <!--cache-->
         <dependency>
             <groupId>org.caffinitas.ohc</groupId>
-            <artifactId>ohc-core-j8</artifactId>
-            <version>0.6.1</version>
+            <artifactId>ohc-core</artifactId>
+            <version>0.7.1</version>
         </dependency>
 
         <!--Testing-->

--- a/nab-starter/src/main/java/ru/hh/nab/starter/server/cache/CacheFilter.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/server/cache/CacheFilter.java
@@ -154,13 +154,4 @@ public class CacheFilter implements Filter {
       httpServletResponse.flushBuffer();
     }
   }
-
-  @Override
-  public void destroy() {
-    try {
-      ohCache.close();
-    } catch (IOException e) {
-      LOGGER.warn("Unable to close http cache", e);
-    }
-  }
 }


### PR DESCRIPTION
Вполне реалистично, что оно тупит, т.к. там вызывается JNI, который блокирует гц, а у нас жава не может сдохнуть
В общем, если крутые пацаны из кассандры не вызывают у этой штуки close, то и нам не следует
По идее память будет в безопасности в любой случае