### PR TITLE
HH-134664 Add max threads metrics to MonitoredThreadPoolExecutor and MonitoredQueuedThreadPool

### DIFF
--- a/nab-starter/src/main/java/ru/hh/nab/starter/server/jetty/MonitoredQueuedThreadPool.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/server/jetty/MonitoredQueuedThreadPool.java
@@ -13,6 +13,7 @@ public class MonitoredQueuedThreadPool extends QueuedThreadPool {
   private final Max busyThreads = new Max(0);
   private final Max idleThreads = new Max(0);
   private final Max totalThreads = new Max(0);
+  private final Max maxThreads = new Max(0);
 
   public MonitoredQueuedThreadPool(int maxThreads, int minThreads, int idleTimeout, BlockingQueue<Runnable> queue,
                                    String poolName, StatsDSender statsDSender) {
@@ -22,6 +23,7 @@ public class MonitoredQueuedThreadPool extends QueuedThreadPool {
     String busyThreadsMetricName = "busyThreads";
     String idleThreadsMetricName = "idleThreads";
     String totalThreadsMetricName = "totalThreads";
+    String maxThreadsMetricName = "maxThreads";
     var sender = new TaggedSender(statsDSender, Set.of(new Tag("pool", poolName)));
 
     statsDSender.sendPeriodically(() -> {
@@ -29,6 +31,7 @@ public class MonitoredQueuedThreadPool extends QueuedThreadPool {
       sender.sendMax(busyThreadsMetricName, busyThreads);
       sender.sendMax(idleThreadsMetricName, idleThreads);
       sender.sendMax(totalThreadsMetricName, totalThreads);
+      sender.sendMax(maxThreadsMetricName, this.maxThreads);
     });
   }
 
@@ -38,6 +41,7 @@ public class MonitoredQueuedThreadPool extends QueuedThreadPool {
     busyThreads.save(getBusyThreads());
     idleThreads.save(getIdleThreads());
     totalThreads.save(getThreads());
+    maxThreads.save(getMaxThreads());
 
     super.execute(job);
   }


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-134664
Добавил новые метрики по максимальному размеру пула для MonitoredThreadPoolExecutor и MonitoredQueuedThreadPool (Jetty). Для пула соединений с БД такая метрика уже существует.