### PR TITLE
HH-142977 add new mappable exception and helper methods, add exception mappers

### DIFF
--- a/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/CompletionExceptionMapper.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/CompletionExceptionMapper.java
@@ -1,0 +1,11 @@
+package ru.hh.nab.starter.exceptions;
+
+import java.util.concurrent.CompletionException;
+import javax.annotation.Priority;
+import javax.ws.rs.ext.Provider;
+import static ru.hh.nab.starter.exceptions.NabExceptionMapper.LOW_PRIORITY;
+
+@Provider
+@Priority(LOW_PRIORITY)
+public class CompletionExceptionMapper extends UnwrappingExceptionMapper<CompletionException> {
+}

--- a/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/ExceptionUtils.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/ExceptionUtils.java
@@ -1,0 +1,26 @@
+package ru.hh.nab.starter.exceptions;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+
+public final class ExceptionUtils {
+  private ExceptionUtils() {
+  }
+
+  public static <T> T getOrThrowMappable(Callable<T> supplier) {
+    try {
+      return supplier.call();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new NabMappableException(e);
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new NabMappableException(e);
+    }
+  }
+
+  public static <T> T getOrThrowMappable(Future<T> future) {
+    return getOrThrowMappable(future::get);
+  }
+}

--- a/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/ExecutionExceptionMapper.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/ExecutionExceptionMapper.java
@@ -1,0 +1,11 @@
+package ru.hh.nab.starter.exceptions;
+
+import java.util.concurrent.ExecutionException;
+import javax.annotation.Priority;
+import javax.ws.rs.ext.Provider;
+import static ru.hh.nab.starter.exceptions.NabExceptionMapper.LOW_PRIORITY;
+
+@Provider
+@Priority(LOW_PRIORITY)
+public class ExecutionExceptionMapper extends UnwrappingExceptionMapper<ExecutionException> {
+}

--- a/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/NabMappableException.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/NabMappableException.java
@@ -1,0 +1,13 @@
+package ru.hh.nab.starter.exceptions;
+
+import static java.util.Objects.requireNonNull;
+import org.glassfish.jersey.server.internal.process.MappableException;
+
+/**
+ * Automatically unwrapped by jersey. See {@link MappableException}.
+ */
+public class NabMappableException extends MappableException {
+  public NabMappableException(Throwable cause) {
+    super("Wrapper exception for jersey mappers", requireNonNull(cause));
+  }
+}

--- a/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/UnwrappingExceptionMapper.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/UnwrappingExceptionMapper.java
@@ -1,0 +1,31 @@
+package ru.hh.nab.starter.exceptions;
+
+import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import org.glassfish.jersey.server.internal.process.MappableException;
+import org.glassfish.jersey.spi.ExceptionMappers;
+
+public abstract class UnwrappingExceptionMapper<T extends Exception> implements ExceptionMapper<T> {
+
+  @Inject
+  private ExceptionMappers mappers;
+
+  @Override
+  public Response toResponse(T exception) {
+    Throwable cause = exception.getCause();
+    if (cause != null) {
+      ExceptionMapper<Throwable> mapper = mappers.findMapping(cause);
+      if (mapper != null) {
+        return mapper.toResponse(cause);
+      }
+
+      if (cause instanceof WebApplicationException) {
+        return ((WebApplicationException) cause).getResponse();
+      }
+    }
+
+    throw new MappableException(cause == null ? exception : cause);
+  }
+}

--- a/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/WebApplicationExceptionMapper.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/WebApplicationExceptionMapper.java
@@ -4,6 +4,7 @@ import javax.annotation.Priority;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
+import static ru.hh.jclient.common.HttpStatuses.INTERNAL_SERVER_ERROR;
 import static ru.hh.nab.starter.exceptions.NabExceptionMapper.LOW_PRIORITY;
 
 @Provider
@@ -15,7 +16,7 @@ public class WebApplicationExceptionMapper extends NabExceptionMapper<WebApplica
 
   @Override
   protected void logException(WebApplicationException wae, LoggingLevel loggingLevel) {
-    if (wae.getCause() == null) {
+    if (wae.getCause() == null && wae.getResponse().getStatus() != INTERNAL_SERVER_ERROR) {
       return;
     }
     if (wae.getResponse().getStatus() < 500) {

--- a/nab-starter/src/main/java/ru/hh/nab/starter/jersey/DefaultResourceConfig.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/jersey/DefaultResourceConfig.java
@@ -4,6 +4,8 @@ import java.util.Collections;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.ServerProperties;
 import ru.hh.nab.starter.exceptions.AnyExceptionMapper;
+import ru.hh.nab.starter.exceptions.CompletionExceptionMapper;
+import ru.hh.nab.starter.exceptions.ExecutionExceptionMapper;
 import ru.hh.nab.starter.exceptions.IllegalArgumentExceptionMapper;
 import ru.hh.nab.starter.exceptions.IllegalStateExceptionMapper;
 import ru.hh.nab.starter.exceptions.NotFoundExceptionMapper;
@@ -20,6 +22,8 @@ public final class DefaultResourceConfig extends ResourceConfig {
     register(MarshallerContextResolver.class);
 
     register(AnyExceptionMapper.class);
+    register(CompletionExceptionMapper.class);
+    register(ExecutionExceptionMapper.class);
     register(IllegalArgumentExceptionMapper.class);
     register(IllegalStateExceptionMapper.class);
     register(NotFoundExceptionMapper.class);


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-142977

Добавил новый unchecked эксепшн-обёртку, чтобы протаскивать checked эксепшны из http-тредов. Чтобы не добавлять маппер для этого эксепшна, заюзал джерсёвый `MappableException`, который автоматически разворачивается (но если в будущем это поведение изменится, можно будет добавить маппер).
Также добавил метод `getOrThrowMappable()` для оборачивания того, что может вылететь из `Callable` или `Future`, в этот эксепшн.

И добавил два маппера - для вытаскивания и маппинга причины из `CompletionException` и `ExecutionException`.
