### PR TITLE
HH-176320 | Support stacktrace for WARN level

### DIFF
--- a/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/NabExceptionMapper.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/NabExceptionMapper.java
@@ -37,6 +37,7 @@ public abstract class NabExceptionMapper<T extends Exception> implements Excepti
   protected enum LoggingLevel {
     NOTHING,
     ERROR_WITH_STACK_TRACE,
+    WARN_WITH_STACK_TRACE,
     WARN_WITHOUT_STACK_TRACE,
     INFO_WITH_STACK_TRACE,
     INFO_WITHOUT_STACK_TRACE,
@@ -65,6 +66,10 @@ public abstract class NabExceptionMapper<T extends Exception> implements Excepti
       }
       case ERROR_WITH_STACK_TRACE: {
         LOGGER.error(exception.getMessage(), exception);
+        break;
+      }
+      case WARN_WITH_STACK_TRACE: {
+        LOGGER.warn(exception.getMessage(), exception);
         break;
       }
       case WARN_WITHOUT_STACK_TRACE: {


### PR DESCRIPTION
### Problem:

As a developer in Skill team, I would like to reduce the level of client errors (as they look like WARNS for me), but still preserve the stacktrace.

### Changes:
* simply add new enum value;
* add new case branch.