### PR TITLE
HH-188298 nab for quarkus

### DIFF
--- a/nab-common/pom.xml
+++ b/nab-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-rc2-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nab-common/pom.xml
+++ b/nab-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1</version>
+        <version>4.40.3.jakarta-quarkus-rc2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nab-common/pom.xml
+++ b/nab-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nab-common/src/main/java/ru/hh/nab/common/qualifier/NamedQualifier.java
+++ b/nab-common/src/main/java/ru/hh/nab/common/qualifier/NamedQualifier.java
@@ -5,6 +5,8 @@ public final class NamedQualifier {
   public static final String SERVICE_NAME = "serviceName";
   public static final String NODE_NAME = "nodeName";
   public static final String DATACENTER = "datacenter";
+  public static final String COMMON_SCHEDULED_EXECUTOR = "commonScheduledExecutor";
+  public static final String PROJECT_PROPERTIES = "projectProperties";
 
   private NamedQualifier() {}
 }

--- a/nab-data-source/pom.xml
+++ b/nab-data-source/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-rc2-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nab-data-source/pom.xml
+++ b/nab-data-source/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1</version>
+        <version>4.40.3.jakarta-quarkus-rc2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nab-data-source/pom.xml
+++ b/nab-data-source/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nab-example/pom.xml
+++ b/nab-example/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-rc2-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nab-example/pom.xml
+++ b/nab-example/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1</version>
+        <version>4.40.3.jakarta-quarkus-rc2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nab-example/pom.xml
+++ b/nab-example/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nab-hibernate/pom.xml
+++ b/nab-hibernate/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-rc2-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nab-hibernate/pom.xml
+++ b/nab-hibernate/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1</version>
+        <version>4.40.3.jakarta-quarkus-rc2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nab-hibernate/pom.xml
+++ b/nab-hibernate/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nab-jclient/pom.xml
+++ b/nab-jclient/pom.xml
@@ -14,6 +14,16 @@
     <name>nuts'n'bolts jclient integration</name>
 
     <dependencies>
+
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>nab-common</artifactId>

--- a/nab-jclient/pom.xml
+++ b/nab-jclient/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1</version>
+        <version>4.40.3.jakarta-quarkus-rc2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-jclient/pom.xml
+++ b/nab-jclient/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-jclient/pom.xml
+++ b/nab-jclient/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-rc2-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-jclient/src/main/java/ru/hh/nab/jclient/JClientContextProvider.java
+++ b/nab-jclient/src/main/java/ru/hh/nab/jclient/JClientContextProvider.java
@@ -1,0 +1,55 @@
+package ru.hh.nab.jclient;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.ext.Provider;
+import java.util.List;
+import java.util.Map;
+import static java.util.Objects.requireNonNull;
+import static java.util.Spliterator.DISTINCT;
+import static java.util.Spliterator.NONNULL;
+import java.util.Spliterators;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+import java.util.stream.StreamSupport;
+import ru.hh.jclient.common.HttpClientContextThreadLocalSupplier;
+
+@Provider
+@ApplicationScoped
+public class JClientContextProvider implements ContainerRequestFilter, ContainerResponseFilter {
+
+  private final HttpClientContextThreadLocalSupplier contextThreadLocalSupplier;
+
+  @Inject
+  public JClientContextProvider(HttpClientContextThreadLocalSupplier contextThreadLocalSupplier) {
+    this.contextThreadLocalSupplier = contextThreadLocalSupplier;
+  }
+
+  private static Map<String, List<String>> getRequestHeadersMap(ContainerRequestContext context) {
+    return StreamSupport
+        .stream(Spliterators.spliteratorUnknownSize(context.getHeaders().keySet().iterator(), DISTINCT | NONNULL), false)
+        .collect(toMap(identity(), h -> List.of(context.getHeaderString(h))));
+  }
+
+  @Override
+  public void filter(ContainerRequestContext containerRequestContext) {
+    requireNonNull(contextThreadLocalSupplier, "httpClientContextSupplier should not be null");
+    try {
+      contextThreadLocalSupplier.addContext(getRequestHeadersMap(containerRequestContext),
+          containerRequestContext.getUriInfo().getQueryParameters(true)
+      );
+    } catch (IllegalArgumentException e) {
+      contextThreadLocalSupplier.clear();
+      throw e;
+    }
+  }
+
+  @Override
+  public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+    contextThreadLocalSupplier.clear();
+  }
+}

--- a/nab-jclient/src/main/java/ru/hh/nab/jclient/NabJClientConfig.java
+++ b/nab-jclient/src/main/java/ru/hh/nab/jclient/NabJClientConfig.java
@@ -8,7 +8,6 @@ import jakarta.inject.Singleton;
 import java.time.Duration;
 import java.util.Optional;
 import static java.util.Optional.ofNullable;
-import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import ru.hh.jclient.common.HttpClientContext;
@@ -17,11 +16,10 @@ import ru.hh.jclient.common.HttpClientEventListener;
 import ru.hh.jclient.common.HttpClientFactoryBuilder;
 import ru.hh.jclient.common.check.GlobalTimeoutCheck;
 import ru.hh.jclient.common.util.storage.MDCStorage;
-import static ru.hh.nab.common.qualifier.NamedQualifier.COMMON_SCHEDULED_EXECUTOR;
 import ru.hh.nab.common.properties.FileSettings;
+import static ru.hh.nab.common.qualifier.NamedQualifier.COMMON_SCHEDULED_EXECUTOR;
 import static ru.hh.nab.common.qualifier.NamedQualifier.SERVICE_NAME;
 import static ru.hh.nab.jclient.UriCompactionUtil.compactUri;
-import ru.hh.nab.jclient.checks.TransactionalCheck;
 
 @ApplicationScoped
 public class NabJClientConfig {
@@ -49,22 +47,6 @@ public class NabJClientConfig {
                 MINUTES.toMillis(sendIntervalMinutes)
             )
         ).withUserAgent(serviceName);
-  }
-
-  @Produces
-  @Singleton
-  TransactionalCheck transactionalCheck(@Named(COMMON_SCHEDULED_EXECUTOR) ScheduledExecutorService executorService, FileSettings fileSettings) {
-    var subSettings = fileSettings.getSubSettings("jclient.listener.transactional-check");
-    long sendIntervalMinutes = ofNullable(subSettings.getInteger("send.interval.minutes")).orElse(1);
-    boolean failOnCheck = ofNullable(subSettings.getBoolean("fail.on.check")).orElse(Boolean.FALSE);
-    int stacktraceDepthLimit = ofNullable(subSettings.getInteger("stacktrace.depth.limit")).orElse(10);
-    var packagesToSkip = ofNullable(subSettings.getStringList("packages.to.skip")).map(Set::copyOf).orElseGet(Set::of);
-    return new TransactionalCheck(
-        failOnCheck ? TransactionalCheck.Action.RAISE : TransactionalCheck.Action.LOG,
-        stacktraceDepthLimit,
-        executorService, MINUTES.toMillis(sendIntervalMinutes),
-        packagesToSkip
-    );
   }
 
   @Produces

--- a/nab-jclient/src/main/java/ru/hh/nab/jclient/TransactionalCheckConfig.java
+++ b/nab-jclient/src/main/java/ru/hh/nab/jclient/TransactionalCheckConfig.java
@@ -1,0 +1,32 @@
+package ru.hh.nab.jclient;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import static java.util.Optional.ofNullable;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static ru.hh.nab.common.qualifier.NamedQualifier.COMMON_SCHEDULED_EXECUTOR;
+import ru.hh.nab.common.properties.FileSettings;
+import ru.hh.nab.jclient.checks.TransactionalCheck;
+
+@ApplicationScoped
+public class TransactionalCheckConfig {
+  @Produces
+  @Singleton
+  TransactionalCheck transactionalCheck(@Named(COMMON_SCHEDULED_EXECUTOR) ScheduledExecutorService executorService, FileSettings fileSettings) {
+    var subSettings = fileSettings.getSubSettings("jclient.listener.transactional-check");
+    long sendIntervalMinutes = ofNullable(subSettings.getInteger("send.interval.minutes")).orElse(1);
+    boolean failOnCheck = ofNullable(subSettings.getBoolean("fail.on.check")).orElse(Boolean.FALSE);
+    int stacktraceDepthLimit = ofNullable(subSettings.getInteger("stacktrace.depth.limit")).orElse(10);
+    var packagesToSkip = ofNullable(subSettings.getStringList("packages.to.skip")).map(Set::copyOf).orElseGet(Set::of);
+    return new TransactionalCheck(
+        failOnCheck ? TransactionalCheck.Action.RAISE : TransactionalCheck.Action.LOG,
+        stacktraceDepthLimit,
+        executorService, MINUTES.toMillis(sendIntervalMinutes),
+        packagesToSkip
+    );
+  }
+}

--- a/nab-jclient/src/main/java/ru/hh/nab/jclient/TransactionalCheckConfig.java
+++ b/nab-jclient/src/main/java/ru/hh/nab/jclient/TransactionalCheckConfig.java
@@ -8,8 +8,8 @@ import static java.util.Optional.ofNullable;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static ru.hh.nab.common.qualifier.NamedQualifier.COMMON_SCHEDULED_EXECUTOR;
 import ru.hh.nab.common.properties.FileSettings;
+import static ru.hh.nab.common.qualifier.NamedQualifier.COMMON_SCHEDULED_EXECUTOR;
 import ru.hh.nab.jclient.checks.TransactionalCheck;
 
 @ApplicationScoped

--- a/nab-kafka/pom.xml
+++ b/nab-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>nuts-and-bolts-parent</artifactId>
         <groupId>ru.hh.nab</groupId>
-        <version>4.40.3.jakarta-quarkus-rc1</version>
+        <version>4.40.3.jakarta-quarkus-rc2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-kafka/pom.xml
+++ b/nab-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>nuts-and-bolts-parent</artifactId>
         <groupId>ru.hh.nab</groupId>
-        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-kafka/pom.xml
+++ b/nab-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>nuts-and-bolts-parent</artifactId>
         <groupId>ru.hh.nab</groupId>
-        <version>4.40.3.jakarta-rc2-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-logging/pom.xml
+++ b/nab-logging/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1</version>
+        <version>4.40.3.jakarta-quarkus-rc2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-logging/pom.xml
+++ b/nab-logging/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-logging/pom.xml
+++ b/nab-logging/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-rc2-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-metrics/pom.xml
+++ b/nab-metrics/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1</version>
+        <version>4.40.3.jakarta-quarkus-rc2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-metrics/pom.xml
+++ b/nab-metrics/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-metrics/pom.xml
+++ b/nab-metrics/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-rc2-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-starter/pom.xml
+++ b/nab-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-rc2-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nab-starter/pom.xml
+++ b/nab-starter/pom.xml
@@ -14,6 +14,12 @@
     <name>nuts'n'bolts application starter</name>
 
     <dependencies>
+
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>ru.hh.nab</groupId>
             <artifactId>nab-common</artifactId>

--- a/nab-starter/pom.xml
+++ b/nab-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1</version>
+        <version>4.40.3.jakarta-quarkus-rc2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nab-starter/pom.xml
+++ b/nab-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nab-starter/src/main/java/ru/hh/nab/starter/NabCommonConfig.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/NabCommonConfig.java
@@ -68,6 +68,7 @@ public class NabCommonConfig {
   }
 
   @Bean
+  @Named(COMMON_SCHEDULED_EXECUTOR)
   ScheduledExecutorService scheduledExecutorService() {
     return new ScheduledExecutor();
   }

--- a/nab-starter/src/main/java/ru/hh/nab/starter/NabCommonConfig.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/NabCommonConfig.java
@@ -1,18 +1,21 @@
 package ru.hh.nab.starter;
 
 import com.timgroup.statsd.StatsDClient;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Optional;
 import static java.util.Optional.ofNullable;
 import java.util.Properties;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Predicate;
-import org.springframework.beans.factory.config.PropertiesFactoryBean;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ClassPathResource;
 import ru.hh.nab.common.executor.ScheduledExecutor;
 import ru.hh.nab.common.properties.FileSettings;
+import ru.hh.nab.common.qualifier.NamedQualifier;
+import static ru.hh.nab.common.qualifier.NamedQualifier.COMMON_SCHEDULED_EXECUTOR;
 import static ru.hh.nab.common.qualifier.NamedQualifier.DATACENTER;
 import static ru.hh.nab.common.qualifier.NamedQualifier.NODE_NAME;
 import static ru.hh.nab.common.qualifier.NamedQualifier.SERVICE_NAME;
@@ -23,7 +26,7 @@ import static ru.hh.nab.starter.server.jetty.JettyServerFactory.createJettyThrea
 import static ru.hh.nab.starter.server.jetty.JettySettingsConstants.JETTY;
 import ru.hh.nab.starter.server.jetty.MonitoredQueuedThreadPool;
 
-@Configuration
+@ApplicationScoped
 public class NabCommonConfig {
 
   private static final String STATSD_DEFAULT_PERIODIC_SEND_INTERVAL = "statsd.defaultPeriodicSendIntervalSec";
@@ -31,29 +34,33 @@ public class NabCommonConfig {
 
   public static final String TEST_PROPERTIES_FILE_NAME = "service-test.properties";
 
+  @Produces
+  @Singleton
   @Named(SERVICE_NAME)
-  @Bean(SERVICE_NAME)
   String serviceName(FileSettings fileSettings) {
     return ofNullable(fileSettings.getString(SERVICE_NAME)).filter(Predicate.not(String::isEmpty))
         .orElseThrow(() -> new RuntimeException(String.format("'%s' property is not found in file settings", SERVICE_NAME)));
   }
 
+  @Produces
+  @Singleton
   @Named(DATACENTER)
-  @Bean(DATACENTER)
   String datacenter(FileSettings fileSettings) {
     return ofNullable(fileSettings.getString(DATACENTER)).filter(Predicate.not(String::isEmpty))
         .orElseThrow(() -> new RuntimeException(String.format("'%s' property is not found in file settings", DATACENTER)));
   }
 
+  @Produces
+  @Singleton
   @Named(NODE_NAME)
-  @Bean(NODE_NAME)
   String nodeName(FileSettings fileSettings) {
     return ofNullable(System.getenv(NODE_NAME_ENV))
         .orElseGet(() -> ofNullable(fileSettings.getString(NODE_NAME)).filter(Predicate.not(String::isEmpty))
             .orElseThrow(() -> new RuntimeException(String.format("'%s' property is not found in file settings", NODE_NAME))));
   }
 
-  @Bean
+  @Produces
+  @Singleton
   MonitoredQueuedThreadPool jettyThreadPool(
       FileSettings fileSettings,
       @Named(SERVICE_NAME) String serviceNameValue,
@@ -62,20 +69,23 @@ public class NabCommonConfig {
     return createJettyThreadPool(fileSettings.getSubSettings(JETTY), serviceNameValue, statsDSender);
   }
 
-  @Bean
+  @Produces
+  @Singleton
   FileSettings fileSettings(@Service Properties serviceProperties) {
     return new FileSettings(serviceProperties);
   }
 
-  @Bean
+  @Produces
+  @Singleton
   @Named(COMMON_SCHEDULED_EXECUTOR)
   ScheduledExecutorService scheduledExecutorService() {
     return new ScheduledExecutor();
   }
 
-  @Bean
+  @Produces
+  @Singleton
   StatsDSender statsDSender(
-      ScheduledExecutorService scheduledExecutorService,
+      @Named(COMMON_SCHEDULED_EXECUTOR) ScheduledExecutorService scheduledExecutorService,
       StatsDClient statsDClient,
       @Named(SERVICE_NAME) String serviceNameValue,
       FileSettings fileSettings
@@ -89,16 +99,24 @@ public class NabCommonConfig {
     return statsDSender;
   }
 
-  @Bean
-  PropertiesFactoryBean projectProperties() {
-    PropertiesFactoryBean projectProps = new PropertiesFactoryBean();
-    projectProps.setLocation(new ClassPathResource(AppMetadata.PROJECT_PROPERTIES));
-    projectProps.setIgnoreResourceNotFound(true);
-    return projectProps;
+  @Produces
+  @Singleton
+  @Named(NamedQualifier.PROJECT_PROPERTIES)
+  Properties projectProperties() {
+    Properties properties = new Properties();
+    try (InputStream resource = Thread.currentThread().getContextClassLoader().getResourceAsStream(AppMetadata.PROJECT_PROPERTIES)) {
+      if (resource != null) {
+        properties.load(resource);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException("Couldn't load project properties", e);
+    }
+    return properties;
   }
 
-  @Bean
-  AppMetadata appMetadata(String serviceName, Properties projectProperties) {
+  @Produces
+  @Singleton
+  AppMetadata appMetadata(@Named(SERVICE_NAME) String serviceName, @Named(NamedQualifier.PROJECT_PROPERTIES) Properties projectProperties) {
     return new AppMetadata(serviceName, projectProperties);
   }
 }

--- a/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/AnyExceptionMapper.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/AnyExceptionMapper.java
@@ -1,6 +1,7 @@
 package ru.hh.nab.starter.exceptions;
 
 import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.core.Response;
 import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static jakarta.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
@@ -13,6 +14,7 @@ import static ru.hh.nab.starter.exceptions.NabExceptionMapper.LOW_PRIORITY;
 
 @Provider
 @Priority(LOW_PRIORITY)
+@ApplicationScoped
 public class AnyExceptionMapper extends NabExceptionMapper<Exception> {
   public AnyExceptionMapper() {
     super(INTERNAL_SERVER_ERROR, LoggingLevel.ERROR_WITH_STACK_TRACE);

--- a/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/CompletionExceptionMapper.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/CompletionExceptionMapper.java
@@ -1,11 +1,13 @@
 package ru.hh.nab.starter.exceptions;
 
 import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.ext.Provider;
 import java.util.concurrent.CompletionException;
 import static ru.hh.nab.starter.exceptions.NabExceptionMapper.LOW_PRIORITY;
 
 @Provider
 @Priority(LOW_PRIORITY)
+@ApplicationScoped
 public class CompletionExceptionMapper extends UnwrappingExceptionMapper<CompletionException> {
 }

--- a/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/ExecutionExceptionMapper.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/ExecutionExceptionMapper.java
@@ -1,11 +1,13 @@
 package ru.hh.nab.starter.exceptions;
 
 import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.ext.Provider;
 import java.util.concurrent.ExecutionException;
 import static ru.hh.nab.starter.exceptions.NabExceptionMapper.LOW_PRIORITY;
 
 @Provider
 @Priority(LOW_PRIORITY)
+@ApplicationScoped
 public class ExecutionExceptionMapper extends UnwrappingExceptionMapper<ExecutionException> {
 }

--- a/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/IllegalArgumentExceptionMapper.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/IllegalArgumentExceptionMapper.java
@@ -1,12 +1,14 @@
 package ru.hh.nab.starter.exceptions;
 
 import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 import jakarta.ws.rs.ext.Provider;
 import static ru.hh.nab.starter.exceptions.NabExceptionMapper.LOW_PRIORITY;
 
 @Provider
 @Priority(LOW_PRIORITY)
+@ApplicationScoped
 public class IllegalArgumentExceptionMapper extends NabExceptionMapper<IllegalArgumentException> {
   public IllegalArgumentExceptionMapper() {
     super(BAD_REQUEST, LoggingLevel.ERROR_WITH_STACK_TRACE);

--- a/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/IllegalStateExceptionMapper.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/IllegalStateExceptionMapper.java
@@ -1,12 +1,14 @@
 package ru.hh.nab.starter.exceptions;
 
 import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
 import static jakarta.ws.rs.core.Response.Status.CONFLICT;
 import jakarta.ws.rs.ext.Provider;
 import static ru.hh.nab.starter.exceptions.NabExceptionMapper.LOW_PRIORITY;
 
 @Provider
 @Priority(LOW_PRIORITY)
+@ApplicationScoped
 public class IllegalStateExceptionMapper extends NabExceptionMapper<IllegalStateException> {
   public IllegalStateExceptionMapper() {
     super(CONFLICT, LoggingLevel.ERROR_WITH_STACK_TRACE);

--- a/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/NabExceptionMapper.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/NabExceptionMapper.java
@@ -1,5 +1,6 @@
 package ru.hh.nab.starter.exceptions;
 
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -11,7 +12,6 @@ import jakarta.ws.rs.ext.ExceptionMapper;
 import static java.util.Optional.ofNullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.ApplicationContext;
 
 /**
  * This exception mapper solves several tasks:
@@ -32,7 +32,7 @@ public abstract class NabExceptionMapper<T extends Exception> implements Excepti
   @Context
   protected HttpServletResponse response;
   @Inject
-  protected ApplicationContext applicationContext;
+  protected Instance<ExceptionSerializer> exceptionSerializers;
 
   protected enum LoggingLevel {
     NOTHING,
@@ -95,7 +95,7 @@ public abstract class NabExceptionMapper<T extends Exception> implements Excepti
   }
 
   protected Response serializeException(Response.StatusType statusCode, T exception) {
-    return applicationContext.getBeansOfType(ExceptionSerializer.class).values().stream()
+    return exceptionSerializers.stream()
       .filter(s -> s.isCompatible(request, response))
       .findFirst()
       .map(s -> s.serializeException(statusCode, exception))

--- a/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/NotFoundExceptionMapper.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/NotFoundExceptionMapper.java
@@ -1,6 +1,7 @@
 package ru.hh.nab.starter.exceptions;
 
 import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
@@ -8,6 +9,7 @@ import static ru.hh.nab.starter.exceptions.NabExceptionMapper.LOW_PRIORITY;
 
 @Provider
 @Priority(LOW_PRIORITY)
+@ApplicationScoped
 public class NotFoundExceptionMapper extends NabExceptionMapper<NotFoundException> {
   public NotFoundExceptionMapper() {
     super(null, LoggingLevel.NOTHING);

--- a/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/SecurityExceptionMapper.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/SecurityExceptionMapper.java
@@ -1,12 +1,14 @@
 package ru.hh.nab.starter.exceptions;
 
 import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
 import static ru.hh.nab.starter.exceptions.NabExceptionMapper.LOW_PRIORITY;
 
 @Provider
 @Priority(LOW_PRIORITY)
+@ApplicationScoped
 public class SecurityExceptionMapper extends NabExceptionMapper<SecurityException> {
   public SecurityExceptionMapper() {
     super(Response.Status.FORBIDDEN, LoggingLevel.INFO_WITHOUT_STACK_TRACE);

--- a/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/UnwrappingExceptionMapper.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/UnwrappingExceptionMapper.java
@@ -1,5 +1,6 @@
 package ru.hh.nab.starter.exceptions;
 
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
@@ -10,13 +11,13 @@ import org.glassfish.jersey.spi.ExceptionMappers;
 public abstract class UnwrappingExceptionMapper<T extends Exception> implements ExceptionMapper<T> {
 
   @Inject
-  private ExceptionMappers mappers;
+  private Instance<ExceptionMappers> mappers;
 
   @Override
   public Response toResponse(T exception) {
     Throwable cause = exception.getCause();
     if (cause != null) {
-      ExceptionMapper<Throwable> mapper = mappers.findMapping(cause);
+      ExceptionMapper<Throwable> mapper = mappers.isResolvable() ? mappers.get().findMapping(cause) : null;
       if (mapper != null) {
         return mapper.toResponse(cause);
       }

--- a/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/WebApplicationExceptionMapper.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/WebApplicationExceptionMapper.java
@@ -1,6 +1,7 @@
 package ru.hh.nab.starter.exceptions;
 
 import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
@@ -11,6 +12,7 @@ import static ru.hh.nab.starter.exceptions.NabExceptionMapper.LOW_PRIORITY;
 
 @Provider
 @Priority(LOW_PRIORITY)
+@ApplicationScoped
 public class WebApplicationExceptionMapper extends NabExceptionMapper<WebApplicationException> {
 
   private static final List<Integer> ALWAYS_LOGGABLE_ERRORS = List.of(INTERNAL_SERVER_ERROR, BAD_GATEWAY);

--- a/nab-starter/src/main/java/ru/hh/nab/starter/filters/CommonHeadersJaxRsFilter.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/filters/CommonHeadersJaxRsFilter.java
@@ -1,0 +1,35 @@
+package ru.hh.nab.starter.filters;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.ext.Provider;
+import java.io.IOException;
+import static java.util.Optional.ofNullable;
+import static ru.hh.jclient.common.HttpHeaderNames.X_OUTER_TIMEOUT_MS;
+import ru.hh.nab.starter.http.RequestContext;
+import ru.hh.nab.starter.server.RequestHeaders;
+
+@Provider
+@ApplicationScoped
+public final class CommonHeadersJaxRsFilter implements ContainerRequestFilter, ContainerResponseFilter {
+  @Override
+  public void filter(ContainerRequestContext requestContext) throws IOException {
+    var source = requestContext.getHeaderString(RequestHeaders.REQUEST_SOURCE);
+    var isLoadTesting = requestContext.getHeaderString(RequestHeaders.LOAD_TESTING) != null;
+    var outerTimeoutMs = requestContext.getHeaderString(X_OUTER_TIMEOUT_MS);
+
+    RequestContext.setRequestSource(source);
+    RequestContext.setLoadTesting(isLoadTesting);
+    RequestContext.setOuterTimeoutMs(ofNullable(outerTimeoutMs).map(Long::valueOf).orElse(null));
+  }
+
+  @Override
+  public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+    RequestContext.clearLoadTesting();
+    RequestContext.clearRequestSource();
+    RequestContext.clearOuterTimeout();
+  }
+}

--- a/nab-starter/src/main/java/ru/hh/nab/starter/filters/ErrorAcceptFilter.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/filters/ErrorAcceptFilter.java
@@ -1,5 +1,6 @@
 package ru.hh.nab.starter.filters;
 
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
@@ -15,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import static ru.hh.jclient.common.HttpHeaderNames.X_HH_ACCEPT_ERRORS;
 
 @Provider
+@ApplicationScoped
 public class ErrorAcceptFilter implements ContainerResponseFilter {
   private static final Logger LOGGER = LoggerFactory.getLogger(ErrorAcceptFilter.class);
 

--- a/nab-starter/src/main/java/ru/hh/nab/starter/filters/RequestIdLoggingJaxRsFilter.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/filters/RequestIdLoggingJaxRsFilter.java
@@ -1,0 +1,33 @@
+package ru.hh.nab.starter.filters;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.ext.Provider;
+import java.io.IOException;
+import ru.hh.nab.common.mdc.MDC;
+import ru.hh.nab.starter.server.RequestHeaders;
+
+@Provider
+@ApplicationScoped
+public final class RequestIdLoggingJaxRsFilter implements ContainerRequestFilter, ContainerResponseFilter {
+  @Override
+  public void filter(ContainerRequestContext requestContext) throws IOException {
+    String requestId = requestContext.getHeaderString(RequestHeaders.REQUEST_ID);
+    if (requestId == null) {
+      requestId = RequestHeaders.EMPTY_REQUEST_ID;
+    }
+    MDC.setRequestId(requestId);
+  }
+
+  @Override
+  public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+    String requestId = requestContext.getHeaderString(RequestHeaders.REQUEST_ID);
+    if (requestId != null) {
+      responseContext.getHeaders().add(RequestHeaders.REQUEST_ID, requestId);
+    }
+    MDC.clearRequestId();
+  }
+}

--- a/nab-starter/src/main/java/ru/hh/nab/starter/filters/ResourceNameLoggingFilter.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/filters/ResourceNameLoggingFilter.java
@@ -1,15 +1,19 @@
 package ru.hh.nab.starter.filters;
 
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
 import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.ext.Provider;
 import org.springframework.util.ClassUtils;
 import ru.hh.nab.common.mdc.MDC;
 import static ru.hh.nab.common.mdc.MDC.CONTROLLER_MDC_KEY;
 
+@Provider
+@ApplicationScoped
 public class ResourceNameLoggingFilter implements ContainerRequestFilter, ContainerResponseFilter {
 
   @Inject

--- a/nab-starter/src/main/java/ru/hh/nab/starter/jersey/MarshallerContextResolver.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/jersey/MarshallerContextResolver.java
@@ -1,7 +1,9 @@
 package ru.hh.nab.starter.jersey;
 
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.ext.ContextResolver;
+import jakarta.ws.rs.ext.Provider;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
@@ -15,6 +17,8 @@ import ru.hh.nab.metrics.StatsDSender;
 import ru.hh.nab.metrics.Tag;
 import ru.hh.nab.metrics.TaggedSender;
 
+@Provider
+@ApplicationScoped
 public class MarshallerContextResolver implements ContextResolver<Marshaller> {
   private final int maxCollectionSize;
   private static final int defaultMaxCollectionSize = 256;

--- a/nab-telemetry-jdbc/pom.xml
+++ b/nab-telemetry-jdbc/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1</version>
+        <version>4.40.3.jakarta-quarkus-rc2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-telemetry-jdbc/pom.xml
+++ b/nab-telemetry-jdbc/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-telemetry-jdbc/pom.xml
+++ b/nab-telemetry-jdbc/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-rc2-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-telemetry-kafka/pom.xml
+++ b/nab-telemetry-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1</version>
+        <version>4.40.3.jakarta-quarkus-rc2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-telemetry-kafka/pom.xml
+++ b/nab-telemetry-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-telemetry-kafka/pom.xml
+++ b/nab-telemetry-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-rc2-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-telemetry/pom.xml
+++ b/nab-telemetry/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1</version>
+        <version>4.40.3.jakarta-quarkus-rc2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-telemetry/pom.xml
+++ b/nab-telemetry/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-telemetry/pom.xml
+++ b/nab-telemetry/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-rc2-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-telemetry/pom.xml
+++ b/nab-telemetry/pom.xml
@@ -14,6 +14,12 @@
     <name>nuts'n'bolts telemetry</name>
 
     <dependencies>
+
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>ru.hh.nab</groupId>
             <artifactId>nab-common</artifactId>

--- a/nab-testbase/pom.xml
+++ b/nab-testbase/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-rc2-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nab-testbase/pom.xml
+++ b/nab-testbase/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1</version>
+        <version>4.40.3.jakarta-quarkus-rc2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nab-testbase/pom.xml
+++ b/nab-testbase/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nab-tests/pom.xml
+++ b/nab-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-rc2-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nab-tests/pom.xml
+++ b/nab-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1</version>
+        <version>4.40.3.jakarta-quarkus-rc2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nab-tests/pom.xml
+++ b/nab-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.nab</groupId>
         <artifactId>nuts-and-bolts-parent</artifactId>
-        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nab-websocket/pom.xml
+++ b/nab-websocket/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>nuts-and-bolts-parent</artifactId>
         <groupId>ru.hh.nab</groupId>
-        <version>4.40.3.jakarta-quarkus-rc1</version>
+        <version>4.40.3.jakarta-quarkus-rc2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-websocket/pom.xml
+++ b/nab-websocket/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>nuts-and-bolts-parent</artifactId>
         <groupId>ru.hh.nab</groupId>
-        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nab-websocket/pom.xml
+++ b/nab-websocket/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>nuts-and-bolts-parent</artifactId>
         <groupId>ru.hh.nab</groupId>
-        <version>4.40.3.jakarta-rc2-SNAPSHOT</version>
+        <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>ru.hh.nab</groupId>
     <artifactId>nuts-and-bolts-parent</artifactId>
     <packaging>pom</packaging>
-    <version>4.40.3.jakarta-rc2-SNAPSHOT</version>
+    <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
 
     <name>nuts'n'bolts parent module</name>
 
@@ -121,6 +121,18 @@
                 <groupId>org.jetbrains</groupId>
                 <artifactId>syslog4j</artifactId>
                 <version>0.9.46</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>4.0.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>3.1.0</version>
             </dependency>
 
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>ru.hh.nab</groupId>
     <artifactId>nuts-and-bolts-parent</artifactId>
     <packaging>pom</packaging>
-    <version>4.40.3.jakarta-quarkus-rc1-SNAPSHOT</version>
+    <version>4.40.3.jakarta-quarkus-rc1</version>
 
     <name>nuts'n'bolts parent module</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>ru.hh.nab</groupId>
     <artifactId>nuts-and-bolts-parent</artifactId>
     <packaging>pom</packaging>
-    <version>4.40.3.jakarta-quarkus-rc1</version>
+    <version>4.40.3.jakarta-quarkus-rc2-SNAPSHOT</version>
 
     <name>nuts'n'bolts parent module</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ru.hh.public-pom</groupId>
         <artifactId>public-pom</artifactId>
-        <version>1.54.1.jakarta-rc1</version>
+        <version>1.54.2.jakarta-rc1</version>
     </parent>
 
     <groupId>ru.hh.nab</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,6 @@
     <scm>
         <connection>scm:git:git@github.com:hhru/nuts-and-bolts.git</connection>
         <developerConnection>scm:git:git@github.com:hhru/nuts-and-bolts.git</developerConnection>
-        <tag>nuts-and-bolts-parent-4.40.3.jakarta-rc1</tag>
+        <tag>nuts-and-bolts-parent-4.40.3.jakarta-quarkus-rc1</tag>
     </scm>
 </project>


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-188298
[1.](https://github.com/hhru/nuts-and-bolts/pull/420/commits/bedc86629ffb629319c6d5cd1f5e57da5df19955) Поднял public pom
[2.](https://github.com/hhru/nuts-and-bolts/pull/420/commits/6fcf030dc6688a246bc24bdbe3618790ba21b380) Отдельная версия для кваркуса
[3.](https://github.com/hhru/nuts-and-bolts/pull/420/commits/4068e3e24c2c309054669178db68e2d8d6c1341c) Добавил пару констан и Named на бин экзекутор сервиса, дальше пригодится
[4](https://github.com/hhru/nuts-and-bolts/pull/420/commits/f18dd30f4a3a7bd82f68ddaf13c3005a403ce95d) nab-jclient. Замена спринговых аннотаций на стандартные. [Табличка](https://quarkus.io/guides/spring-di#conversion-table) конвертации + явно указываю scope `@Singleton`, т.к. дефолтные scope cdi и spring отличаются. Файлик beans.xml нужен, чтобы клиенты библиотеки знали, что [нужно](https://quarkus.io/guides/cdi-reference#bean_discovery) посканить ее на наличие бинов
[5.](https://github.com/hhru/nuts-and-bolts/pull/420/commits/76bee2ef78b1811a747a0ff49940b9fed1487287) Вытащил TransactionalCheck в отдельный класс, чтобы можно было исключить в нотах. Там оно не надо
[6.](https://github.com/hhru/nuts-and-bolts/pull/420/commits/d9108c506fe07e289eefbe837f643361be303caa) контекст провайдер для жклиента, только не на сервлет фильтрах, а на jax-rs
[7.](https://github.com/hhru/nuts-and-bolts/pull/420/commits/8092a9e2c7eb7b7460557f3838006bf3c3a6c492) То же, что и 4, только для nab-telemetry
[8.](https://github.com/hhru/nuts-and-bolts/pull/420/commits/cade23a3455eb19f0a5446dc9a85db3b3f688075) То же, что и 4, только для nab-starter
[9.](https://github.com/hhru/nuts-and-bolts/pull/420/commits/e4c4a8d21dbb56b9a284937b5bea54e1b6f4801a) Меньше спринговых зависимостей
[10.](https://github.com/hhru/nuts-and-bolts/pull/420/commits/51f93857d819ce07f04c27e7b2e38c37f5c5e254) Повесил аннотации, чтобы то, что регали руками для джетти, подхватывалось автоматом
[11.](https://github.com/hhru/nuts-and-bolts/pull/420/commits/1ee6675c9430e65d5248062a0f84fc079bdd5df1) Еще фильтры
[12.](https://github.com/hhru/nuts-and-bolts/pull/420/commits/75c1e7114b9e7035f9e47d281526043106b765ef) checkstyle
[13.](https://github.com/hhru/nuts-and-bolts/pull/420/commits/c48229bab32501d5a46d956aa1e28ec4955c5a5a) В кваркусе нет этой зависимости в контексте