### PR TITLE
HH-199975 write unstructured logs to .rlog

### DIFF
--- a/nab-logging/src/main/java/ru/hh/nab/logging/HhRollingAppender.java
+++ b/nab-logging/src/main/java/ru/hh/nab/logging/HhRollingAppender.java
@@ -16,7 +16,7 @@ import org.apache.commons.lang3.StringUtils;
  * Is a combo of {@link RollingFileAppender}, {@link FixedWindowRollingPolicy},
  * {@link DefaultTimeBasedFileNamingAndTriggeringPolicy}, {@link TimeBasedRollingPolicy}.
  * <p/>
- * <p>Main file is set to {@code $log.dir/appendername.log}. Rolled file is set to {@code $log.dir/appendername.%i.gz}.
+ * <p>Main file is set to {@code $log.dir/appendername.rlog}. Rolled file is set to {@code $log.dir/appendername.%i.gz}.
  * Layout pattern is set to {@code $log.pattern}.
  * <p/>
  * <p>Other properties, same value for all appenders, but can be overriden by appender attribute (see setter methods).
@@ -221,7 +221,7 @@ public class HhRollingAppender extends RollingFileAppender<ILoggingEvent> {
         throw new IllegalArgumentException(
             String.format("appender name cannot have filesystem path elements: %s", getName()));
       }
-      setFile(String.format("%s/%s.log", propLogdir, getName()));
+      setFile(String.format("%s/%s.rlog", propLogdir, getName()));
     }
 
     if (getRollingPolicy() == null) {

--- a/nab-logging/src/main/java/ru/hh/nab/logging/HhSyslogAppender.java
+++ b/nab-logging/src/main/java/ru/hh/nab/logging/HhSyslogAppender.java
@@ -59,7 +59,7 @@ public class HhSyslogAppender extends Syslog4jAppender<ILoggingEvent> {
   }
 
   private String generateIdent(String tag) {
-    return (StringUtils.isNotEmpty(tag) ? tag + SYSLOG_DELIMITER : "") + getName() + (json ? ".slog" : ".log") + SYSLOG_DELIMITER;
+    return (StringUtils.isNotEmpty(tag) ? tag + SYSLOG_DELIMITER : "") + getName() + (json ? ".slog" : ".rlog") + SYSLOG_DELIMITER;
   }
 
   protected Layout<ILoggingEvent> buildDefaultLayout() {

--- a/nab-logging/src/test/java/ru/hh/nab/logging/HhSyslogAppenderTest.java
+++ b/nab-logging/src/test/java/ru/hh/nab/logging/HhSyslogAppenderTest.java
@@ -33,7 +33,7 @@ public class HhSyslogAppenderTest {
     testLogging(
         hhSyslogAppenderFunction,
         "test",
-        "<11>test/test.log/: ["
+        "<11>test/test.rlog/: ["
             + epochStart.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss,SSS"))
             + "] ERROR logger:1 mdc={} - message",
         "message"
@@ -69,7 +69,7 @@ public class HhSyslogAppenderTest {
     testLogging(
         hhSyslogAppenderFunction,
         "test",
-        "<11>test/test.log/: ["
+        "<11>test/test.rlog/: ["
             + epochStart.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss,SSS"))
             + "] ERROR logger:1 mdc={} - сообщение", "сообщение"
     );
@@ -87,7 +87,7 @@ public class HhSyslogAppenderTest {
       patternLayout.start();
       return appender;
     };
-    testLogging(hhSyslogAppenderFunction, "test", "<11>test/test.log/: message", "message");
+    testLogging(hhSyslogAppenderFunction, "test", "<11>test/test.rlog/: message", "message");
   }
 
   protected void testLogging(


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-199975

чейнжлог:
4.43.0
компатибл фалс
Неструктурированные логи теперь будут писаться в файлы .rlog, ранее писались в .log. Для сервисов ххру важно проверить, что нету кастомных настроек для логов, например так https://github.com/search?q=org%3Ahhru+criteria.log&type=code