### PR TITLE
HH-201807 fix UnsupportedOperationException in jdebug

### DIFF
--- a/nab-starter/src/main/java/ru/hh/nab/starter/filters/ErrorAcceptFilter.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/filters/ErrorAcceptFilter.java
@@ -2,6 +2,7 @@ package ru.hh.nab.starter.filters;
 
 import java.io.IOException;
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.List;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
@@ -26,16 +27,12 @@ public class ErrorAcceptFilter implements ContainerResponseFilter {
         try {
           List<AcceptableMediaType> acceptableMediaTypes = HttpHeaderReader.readAcceptMediaType(acceptErrors);
           if (!acceptableMediaTypes.isEmpty()) {
-            responseContext.getHeaders().replace(CONTENT_TYPE, List.of(acceptableMediaTypes.get(0).toString()));
+            responseContext.getHeaders().replace(CONTENT_TYPE, new ArrayList<>(List.of(acceptableMediaTypes.get(0).toString())));
           } else {
-            LOGGER.warn(
-                "No valid AcceptableMediaType for errors found in {} header: {}",
-                X_HH_ACCEPT_ERRORS,
-                acceptErrors
-            );
+            LOGGER.warn("No valid AcceptableMediaType for errors found in {} header: {}", X_HH_ACCEPT_ERRORS, acceptErrors);
           }
         } catch (ParseException e) {
-          LOGGER.warn("Error while parcing {} header.", X_HH_ACCEPT_ERRORS, e);
+          LOGGER.warn("Error while parsing {} header.", X_HH_ACCEPT_ERRORS, e);
         }
       }
     }


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-201807

Если передан заголовок `X-HH-AcceptErrors` и статус ответа неуспешный и всё происходит под jdebug-ом, то вылетает
```
Caused by: java.lang.UnsupportedOperationException: null
    at java.base/java.util.ImmutableCollections.uoe(ImmutableCollections.java:142)
    at java.base/java.util.ImmutableCollections$AbstractImmutableCollection.clear(ImmutableCollections.java:149)
    at javax.ws.rs.core.AbstractMultivaluedMap.putSingle(AbstractMultivaluedMap.java:74)
    at ru.hh.jdebug.jersey2.provider.DebugInterceptor.lambda$aroundWriteTo$1(DebugInterceptor.java:62)
    at java.base/java.util.Map.forEach(Map.java:713)
    at ru.hh.jdebug.jersey2.provider.DebugInterceptor.aroundWriteTo(DebugInterceptor.java:62)
    ...
```
([DebugInterceptor.java:62](https://github.com/hhru/hh-java-libs/blob/jdebug-0.7.0/jdebug/impl-jersey2/src/main/java/ru/hh/jdebug/jersey2/provider/DebugInterceptor.java#L62))
