### PR TITLE
HH-214991 support builder-style for kafka consumer

### DIFF
--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/ConsumerBuilder.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/ConsumerBuilder.java
@@ -1,0 +1,22 @@
+package ru.hh.nab.kafka.consumer;
+
+import java.util.function.BiFunction;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.slf4j.Logger;
+
+public interface ConsumerBuilder<T> {
+
+  ConsumerBuilder<T> withClientId(String clientId);
+
+  ConsumerBuilder<T> withOperationName(String operationName);
+
+  ConsumerBuilder<T> withConsumeStrategy(ConsumeStrategy<T> consumeStrategy);
+
+  ConsumerBuilder<T> withLogger(Logger logger);
+
+  ConsumerBuilder<T> withAckProvider(BiFunction<KafkaConsumer<T>, Consumer<?, ?>, Ack<T>> ackProvider);
+
+  ConsumerBuilder<T> withUseConsumerGroup(boolean useConsumerGroup);
+
+  KafkaConsumer<T> start();
+}

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/DefaultConsumerBuilder.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/DefaultConsumerBuilder.java
@@ -1,0 +1,106 @@
+package ru.hh.nab.kafka.consumer;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.slf4j.Logger;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.listener.AbstractMessageListenerContainer;
+import org.springframework.kafka.listener.BatchConsumerAwareMessageListener;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+import org.springframework.kafka.listener.ContainerProperties;
+import ru.hh.nab.kafka.util.ConfigProvider;
+import static ru.hh.nab.kafka.util.ConfigProvider.CONCURRENCY;
+
+public class DefaultConsumerBuilder<T> implements ConsumerBuilder<T> {
+
+  private final String topicName;
+  private final Class<T> messageClass;
+  private final DefaultConsumerFactory consumerFactory;
+  private String operationName;
+  private String clientId;
+  private boolean useConsumerGroup = true; // FALSE value not supported now
+  private ConsumeStrategy<T> consumeStrategy;
+  private Logger logger;
+  private BiFunction<KafkaConsumer<T>, Consumer<?, ?>, Ack<T>> ackProvider;
+
+  public DefaultConsumerBuilder(DefaultConsumerFactory consumerFactory, String topicName, Class<T> messageClass) {
+    this.topicName = topicName;
+    this.messageClass = messageClass;
+    this.consumerFactory = consumerFactory;
+
+    withAckProvider((kafkaConsumer, nativeKafkaConsumer) -> new KafkaInternalTopicAck<>(kafkaConsumer, nativeKafkaConsumer));
+  }
+
+  @Override
+  public DefaultConsumerBuilder<T> withOperationName(String operationName) {
+    this.operationName = operationName;
+    return this;
+  }
+
+  @Override
+  public DefaultConsumerBuilder<T> withConsumeStrategy(ConsumeStrategy<T> consumeStrategy) {
+    this.consumeStrategy = consumeStrategy;
+    return this;
+  }
+
+  @Override
+  public DefaultConsumerBuilder<T> withLogger(Logger logger) {
+    this.logger = logger;
+    return this;
+  }
+
+  @Override
+  public DefaultConsumerBuilder<T> withAckProvider(BiFunction<KafkaConsumer<T>, Consumer<?, ?>, Ack<T>> ackProvider) {
+    this.ackProvider = ackProvider;
+    return this;
+  }
+
+  @Override
+  public ConsumerBuilder<T> withUseConsumerGroup(boolean useConsumerGroup) {
+    this.useConsumerGroup = useConsumerGroup;
+    return this;
+  }
+
+  @Override
+  public ConsumerBuilder<T> withClientId(String clientId) {
+    this.clientId = clientId;
+    return this;
+  }
+
+  @Override
+  public KafkaConsumer<T> start() {
+    ConfigProvider configProvider = consumerFactory.getConfigProvider();
+
+    ConsumerFactory<String, T> springConsumerFactory = consumerFactory.getSpringConsumerFactory(topicName, messageClass);
+
+    ConsumerGroupId consumerGroupId = new ConsumerGroupId(configProvider.getServiceName(), topicName, operationName);
+
+    Function<KafkaConsumer<T>, AbstractMessageListenerContainer<String, T>> springContainerProvider = (kafkaConsumer) -> {
+      ContainerProperties containerProperties = consumerFactory.getSpringConsumerContainerProperties(
+          Optional.ofNullable(clientId).orElseGet(() -> UUID.randomUUID().toString()),
+          consumerGroupId,
+          (BatchConsumerAwareMessageListener<String, T>) kafkaConsumer::onMessagesBatch,
+          topicName
+      );
+      SeekToFirstNotAckedMessageErrorHandler<T> errorHandler = consumerFactory.getCommonErrorHandler(topicName, kafkaConsumer, logger);
+
+      ConcurrentMessageListenerContainer<String, T> container = new ConcurrentMessageListenerContainer<>(springConsumerFactory, containerProperties);
+      container.setCommonErrorHandler(errorHandler);
+      container.setConcurrency(configProvider.getNabConsumerSettings(topicName).getInteger(CONCURRENCY, 1));
+      return container;
+    };
+
+    KafkaConsumer<T> kafkaConsumer = new KafkaConsumer<>(
+        consumerFactory.interceptConsumeStrategy(consumerGroupId, consumeStrategy),
+        springContainerProvider,
+        ackProvider
+    );
+    kafkaConsumer.start();
+    logger.info("Subscribed for {}, consumer group id {}", topicName, consumerGroupId);
+    return kafkaConsumer;
+  }
+
+}

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/DefaultConsumerFactory.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/DefaultConsumerFactory.java
@@ -77,7 +77,7 @@ public class DefaultConsumerFactory implements KafkaConsumerFactory {
 
   @Override
   public <T> KafkaConsumer<T> subscribe(String topicName, String operationName, Class<T> messageClass, ConsumeStrategy<T> consumeStrategy) {
-    return subscribe(topicName, messageClass)
+    return builder(topicName, messageClass)
         .withOperationName(operationName)
         .withConsumeStrategy(consumeStrategy)
         .start();
@@ -91,7 +91,7 @@ public class DefaultConsumerFactory implements KafkaConsumerFactory {
       ConsumeStrategy<T> consumeStrategy,
       Logger logger
   ) {
-    return subscribe(topicName, messageClass)
+    return builder(topicName, messageClass)
         .withLogger(logger)
         .withOperationName(operationName)
         .withConsumeStrategy(consumeStrategy)
@@ -102,7 +102,7 @@ public class DefaultConsumerFactory implements KafkaConsumerFactory {
   public <T> KafkaConsumer<T> subscribe(
       String clientId, String topicName, String operationName, Class<T> messageClass, ConsumeStrategy<T> consumeStrategy, Logger logger
   ) {
-    return subscribe(topicName, messageClass)
+    return builder(topicName, messageClass)
         .withLogger(logger)
         .withOperationName(operationName)
         .withConsumeStrategy(consumeStrategy)
@@ -111,7 +111,7 @@ public class DefaultConsumerFactory implements KafkaConsumerFactory {
   }
 
   @Override
-  public <T> ConsumerBuilder<T> subscribe(String topicName, Class<T> messageClass) {
+  public <T> ConsumerBuilder<T> builder(String topicName, Class<T> messageClass) {
     return new DefaultConsumerBuilder<>(this, topicName, messageClass)
         .withLogger(factoryLogger);
   }

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/FailFastDefaultKafkaConsumerFactory.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/FailFastDefaultKafkaConsumerFactory.java
@@ -13,13 +13,6 @@ class FailFastDefaultKafkaConsumerFactory<K, V> extends DefaultKafkaConsumerFact
 
   private final String topicName;
 
-  public FailFastDefaultKafkaConsumerFactory(String topicName,
-                                             Map<String, Object> configs,
-                                             Deserializer<K> keyDeserializer,
-                                             Deserializer<V> valueDeserializer) {
-    super(configs, keyDeserializer, valueDeserializer);
-    this.topicName = topicName;
-  }
 
   public FailFastDefaultKafkaConsumerFactory(
       String topicName,
@@ -28,7 +21,8 @@ class FailFastDefaultKafkaConsumerFactory<K, V> extends DefaultKafkaConsumerFact
       Deserializer<V> valueDeserializer,
       Supplier<String> bootstrapServersSupplier
   ) {
-    this(topicName, configs, keyDeserializer, valueDeserializer);
+    super(configs, keyDeserializer, valueDeserializer);
+    this.topicName = topicName;
     this.setBootstrapServersSupplier(bootstrapServersSupplier);
   }
 

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/KafkaConsumerFactory.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/KafkaConsumerFactory.java
@@ -5,7 +5,7 @@ import org.slf4j.Logger;
 public interface KafkaConsumerFactory {
 
   /**
-   * @deprecated Use {@link KafkaConsumerFactory#subscribe(String, Class) instead}
+   * @deprecated Use {@link KafkaConsumerFactory#builder(String, Class) instead}
    */
   @Deprecated
   <T> KafkaConsumer<T> subscribe(
@@ -17,7 +17,7 @@ public interface KafkaConsumerFactory {
 
 
   /**
-   * @deprecated Use {@link KafkaConsumerFactory#subscribe(String, Class) instead}
+   * @deprecated Use {@link KafkaConsumerFactory#builder(String, Class) instead}
    */
   @Deprecated
   <T> KafkaConsumer<T> subscribe(
@@ -29,7 +29,7 @@ public interface KafkaConsumerFactory {
   );
 
   /**
-   * @deprecated Use {@link KafkaConsumerFactory#subscribe(String, Class) instead}
+   * @deprecated Use {@link KafkaConsumerFactory#builder(String, Class) instead}
    */
   @Deprecated
   <T> KafkaConsumer<T> subscribe(
@@ -41,6 +41,6 @@ public interface KafkaConsumerFactory {
       Logger logger
   );
 
-  <T> ConsumerBuilder<T> subscribe(String topicName, Class<T> messageClass);
+  <T> ConsumerBuilder<T> builder(String topicName, Class<T> messageClass);
 
 }

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/KafkaConsumerFactory.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/KafkaConsumerFactory.java
@@ -4,22 +4,43 @@ import org.slf4j.Logger;
 
 public interface KafkaConsumerFactory {
 
-  <T> KafkaConsumer<T> subscribe(String topicName,
-                                 String operationName,
-                                 Class<T> messageClass,
-                                 ConsumeStrategy<T> messageConsumer);
+  /**
+   * @deprecated Use {@link KafkaConsumerFactory#subscribe(String, Class) instead}
+   */
+  @Deprecated
+  <T> KafkaConsumer<T> subscribe(
+      String topicName,
+      String operationName,
+      Class<T> messageClass,
+      ConsumeStrategy<T> consumeStrategy
+  );
 
-  <T> KafkaConsumer<T> subscribe(String topicName,
-                                 String operationName,
-                                 Class<T> messageClass,
-                                 ConsumeStrategy<T> messageConsumer,
-                                 Logger logger);
 
-  <T> KafkaConsumer<T> subscribe(String clientId,
-                                 String topicName,
-                                 String operationName,
-                                 Class<T> messageClass,
-                                 ConsumeStrategy<T> messageConsumer,
-                                 Logger logger);
+  /**
+   * @deprecated Use {@link KafkaConsumerFactory#subscribe(String, Class) instead}
+   */
+  @Deprecated
+  <T> KafkaConsumer<T> subscribe(
+      String topicName,
+      String operationName,
+      Class<T> messageClass,
+      ConsumeStrategy<T> consumeStrategy,
+      Logger logger
+  );
+
+  /**
+   * @deprecated Use {@link KafkaConsumerFactory#subscribe(String, Class) instead}
+   */
+  @Deprecated
+  <T> KafkaConsumer<T> subscribe(
+      String clientId,
+      String topicName,
+      String operationName,
+      Class<T> messageClass,
+      ConsumeStrategy<T> consumeStrategy,
+      Logger logger
+  );
+
+  <T> ConsumerBuilder<T> subscribe(String topicName, Class<T> messageClass);
 
 }

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/KafkaInternalTopicAck.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/KafkaInternalTopicAck.java
@@ -15,8 +15,7 @@ public class KafkaInternalTopicAck<T> implements Ack<T> {
   private final KafkaConsumer<T> kafkaConsumer;
   private final Consumer<?, ?> consumer;
 
-  public KafkaInternalTopicAck(KafkaConsumer<T> kafkaConsumer,
-                               Consumer<?, ?> consumer) {
+  public KafkaInternalTopicAck(KafkaConsumer<T> kafkaConsumer, Consumer<?, ?> consumer) {
     this.kafkaConsumer = kafkaConsumer;
     this.consumer = consumer;
   }

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/SimpleKafkaConsumer.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/SimpleKafkaConsumer.java
@@ -15,16 +15,16 @@ public abstract class SimpleKafkaConsumer<M> implements MessageProcessor<M>, Clo
   protected final KafkaConsumer<M> kafkaConsumer;
 
   protected SimpleKafkaConsumer(
-      KafkaConsumerFactory kafkaConsumerFactory, 
-      String topic, 
+      KafkaConsumerFactory kafkaConsumerFactory,
+      String topic,
       String operationName,
       Class<M> messageClass) {
     this(kafkaConsumerFactory, topic, operationName, ConsumeStrategy::atLeastOnceWithBatchAck, messageClass);
   }
 
   protected SimpleKafkaConsumer(
-      KafkaConsumerFactory kafkaConsumerFactory, 
-      String topic, 
+      KafkaConsumerFactory kafkaConsumerFactory,
+      String topic,
       String operationName,
       Function<MessageProcessor<M>, ConsumeStrategy<M>> consumeStrategyCreator,
       Class<M> messageClass) {
@@ -49,7 +49,12 @@ public abstract class SimpleKafkaConsumer<M> implements MessageProcessor<M>, Clo
     }
 
     this.logger = logger;
-    this.kafkaConsumer = consumerFactory.subscribe(topic, operationName, messageClass, consumeStrategyCreator.apply(this), this.logger);
+    this.kafkaConsumer = consumerFactory
+        .builder(topic, messageClass)
+        .withLogger(this.logger)
+        .withOperationName(operationName)
+        .withConsumeStrategy(consumeStrategyCreator.apply(this))
+        .start();
   }
 
   @Override

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/monitoring/MonitoringConsumeStrategy.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/monitoring/MonitoringConsumeStrategy.java
@@ -19,9 +19,11 @@ public class MonitoringConsumeStrategy<T> implements ConsumeStrategy<T> {
   private final AtomicLong processingId = new AtomicLong(0);
   private final ConsumerGroupId consumerGroupId;
 
-  public MonitoringConsumeStrategy(StatsDSender statsDSender,
-                                   ConsumerGroupId consumerGroupId,
-                                   ConsumeStrategy<T> consumeStrategy) {
+  public MonitoringConsumeStrategy(
+      StatsDSender statsDSender,
+      ConsumerGroupId consumerGroupId,
+      ConsumeStrategy<T> consumeStrategy
+  ) {
     this.consumerGroupId = consumerGroupId;
     this.timings = buildTimings(statsDSender, consumerGroupId);
     this.consumeStrategy = consumeStrategy;

--- a/nab-telemetry-kafka/src/main/java/ru/hh/nab/telemetry/TelemetryAwareConsumerFactory.java
+++ b/nab-telemetry-kafka/src/main/java/ru/hh/nab/telemetry/TelemetryAwareConsumerFactory.java
@@ -62,8 +62,9 @@ public class TelemetryAwareConsumerFactory extends DefaultConsumerFactory {
   }
 
   @Override
-  protected <T> ConsumeStrategy<T> prepare(ConsumerGroupId consumerGroupId, ConsumeStrategy<T> consumeStrategy) {
+  public <T> ConsumeStrategy<T> interceptConsumeStrategy(ConsumerGroupId consumerGroupId, ConsumeStrategy<T> consumeStrategy) {
     return new TelemetryConsumeStrategyWrapper<>(
-        configProvider.getKafkaClusterName(), super.prepare(consumerGroupId, consumeStrategy), consumerGroupId, telemetry);
+        configProvider.getKafkaClusterName(), super.interceptConsumeStrategy(consumerGroupId, consumeStrategy), consumerGroupId, telemetry
+    );
   }
 }

--- a/nab-tests/src/test/java/ru/hh/nab/kafka/consumer/KafkaConsumerTestbase.java
+++ b/nab-tests/src/test/java/ru/hh/nab/kafka/consumer/KafkaConsumerTestbase.java
@@ -34,7 +34,11 @@ public abstract class KafkaConsumerTestbase {
   }
 
   protected <T> KafkaConsumer<T> startMessagesConsumer(Class<T> messageClass, String operation, ConsumeStrategy<T> consumerMock) {
-    KafkaConsumer<T> consumer = consumerFactory.subscribe(topicName, "testOperation", messageClass, consumerMock);
+    KafkaConsumer<T> consumer = consumerFactory
+        .builder(topicName, messageClass)
+        .withOperationName(operation)
+        .withConsumeStrategy(consumerMock)
+        .start();
     await()
         .atMost(10, TimeUnit.SECONDS)
         .untilAsserted(() -> assertEquals(5, consumer.getAssignedPartitions().size()));

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ru.hh.public-pom</groupId>
         <artifactId>public-pom</artifactId>
-        <version>1.57.0</version>
+        <version>1.57.2</version>
     </parent>
 
     <groupId>ru.hh.nab</groupId>


### PR DESCRIPTION
> [!IMPORTANT] 
> Добавь в описание PR changelog в формате:

- [ ] **version change**  MINOR
- [ ] **description**: меняем логику старта кафка-консумера - теперь он собирается в builder формате. Связано с тем что параметров будет много и стало неудобно их все вместе в subscribe-метод встраивать
- [ ] **requires_changes_in_hh** false
- [ ] **instructions** N/A
