### PR TITLE
HH-216686 return response with Content-Type=application/json in NabExceptionMapper by default

### DIFF
--- a/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/NabExceptionMapper.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/exceptions/NabExceptionMapper.java
@@ -5,6 +5,7 @@ import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.Context;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import org.slf4j.Logger;
@@ -113,7 +114,7 @@ public abstract class NabExceptionMapper<T extends Exception> implements Excepti
               exception.getClass().getCanonicalName(),
               ofNullable(exception.getMessage()).orElse("")
           );
-          return Response.status(statusCode).entity(errors).build();
+          return Response.status(statusCode).type(APPLICATION_JSON).entity(errors).build();
         });
   }
 }

--- a/nab-tests/src/test/java/ru/hh/nab/starter/exceptions/CustomExceptionMappersTest.java
+++ b/nab-tests/src/test/java/ru/hh/nab/starter/exceptions/CustomExceptionMappersTest.java
@@ -45,6 +45,7 @@ public class CustomExceptionMappersTest {
 
     assertEquals(INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
     assertEquals("Any exception", getErrorDescription(response));
+    assertEquals(APPLICATION_JSON_TYPE, response.getMediaType());
 
     response = resourceHelper.executeGet("/any?customSerializer=true");
 

--- a/nab-tests/src/test/java/ru/hh/nab/starter/exceptions/NabExceptionMappersTest.java
+++ b/nab-tests/src/test/java/ru/hh/nab/starter/exceptions/NabExceptionMappersTest.java
@@ -9,6 +9,7 @@ import java.util.stream.IntStream;
 import javax.ws.rs.Path;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static javax.ws.rs.core.MediaType.TEXT_HTML_TYPE;
 import javax.ws.rs.core.Response;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
@@ -50,16 +51,19 @@ public class NabExceptionMappersTest {
 
     assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
     assertEquals("IAE", getErrorDescription(response));
+    assertEquals(APPLICATION_JSON_TYPE, response.getMediaType());
 
     response = resourceHelper.executeGet("/ise");
 
     assertEquals(CONFLICT.getStatusCode(), response.getStatus());
     assertEquals("ISE", getErrorDescription(response));
+    assertEquals(APPLICATION_JSON_TYPE, response.getMediaType());
 
     response = resourceHelper.executeGet("/se");
 
     assertEquals(FORBIDDEN.getStatusCode(), response.getStatus());
     assertEquals("SE", getErrorDescription(response));
+    assertEquals(APPLICATION_JSON_TYPE, response.getMediaType());
 
     response = resourceHelper.executeGet("/wae");
 
@@ -82,6 +86,7 @@ public class NabExceptionMappersTest {
 
     assertEquals(INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
     assertEquals("Any exception", getErrorDescription(response));
+    assertEquals(APPLICATION_JSON_TYPE, response.getMediaType());
 
     response = resourceHelper.executeGet("/notFound");
 


### PR DESCRIPTION
- [ ] **version change** <!--[MAJOR|MINOR|PATCH]-->: MINOR
- [ ] **description**: ExceptionMapper'ы по дефолту возвращают ответ с Content-Type=application/json
- [ ] **requires_changes_in_hh** <!-- [true|false] -->: true
- [ ] **instructions** <!-- [if requires_changes_in_hh]-->: Если требуется, чтобы при возникновении исключений возвращался ответ с Content-Type, отличным от application/json, то необходимо заимплементить ExceptionSerializer
