### PR TITLE
HH-225900 nab-testbase: add NoopKafkaConsumerFactory

### DIFF
--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/KafkaConsumer.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/KafkaConsumer.java
@@ -178,7 +178,7 @@ public class KafkaConsumer<T> {
     }
   }
 
-  private void createNewSpringContainer() {
+  protected void createNewSpringContainer() {
     if (springContainerProvider != null) {
       currentSpringKafkaContainer = springContainerProvider.apply(this);
       return;

--- a/nab-testbase/pom.xml
+++ b/nab-testbase/pom.xml
@@ -31,6 +31,10 @@
         </dependency>
 
         <dependency>
+            <groupId>ru.hh.nab</groupId>
+            <artifactId>nab-kafka</artifactId>
+        </dependency>
+        <dependency>
             <groupId>ru.hh.kafka.test</groupId>
             <artifactId>hh-kafka-test-utils</artifactId>
             <version>1.0.0</version>

--- a/nab-testbase/src/main/java/ru/hh/nab/testbase/kafka/NoopConsumerBuilder.java
+++ b/nab-testbase/src/main/java/ru/hh/nab/testbase/kafka/NoopConsumerBuilder.java
@@ -1,0 +1,59 @@
+package ru.hh.nab.testbase.kafka;
+
+import java.time.Duration;
+import java.util.function.BiFunction;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.slf4j.Logger;
+import ru.hh.nab.kafka.consumer.Ack;
+import ru.hh.nab.kafka.consumer.ConsumeStrategy;
+import ru.hh.nab.kafka.consumer.ConsumerBuilder;
+import ru.hh.nab.kafka.consumer.KafkaConsumer;
+import ru.hh.nab.kafka.consumer.SeekPosition;
+
+public class NoopConsumerBuilder<T> implements ConsumerBuilder<T> {
+
+  @Override
+  public ConsumerBuilder<T> withClientId(String clientId) {
+    return this;
+  }
+
+  @Override
+  public ConsumerBuilder<T> withOperationName(String operationName) {
+    return this;
+  }
+
+  @Override
+  public ConsumerBuilder<T> withConsumeStrategy(ConsumeStrategy<T> consumeStrategy) {
+    return this;
+  }
+
+  @Override
+  public ConsumerBuilder<T> withLogger(Logger logger) {
+    return this;
+  }
+
+  @Override
+  public ConsumerBuilder<T> withAckProvider(BiFunction<KafkaConsumer<T>, Consumer<?, ?>, Ack<T>> ackProvider) {
+    return this;
+  }
+
+  @Override
+  public ConsumerBuilder<T> withConsumerGroup() {
+    return this;
+  }
+
+  @Override
+  public ConsumerBuilder<T> withAllPartitionsAssigned(SeekPosition seekPosition, Duration checkNewPartitionsInterval) {
+    return this;
+  }
+
+  @Override
+  public ConsumerBuilder<T> withAllPartitionsAssigned(SeekPosition seekPosition) {
+    return this;
+  }
+
+  @Override
+  public KafkaConsumer<T> start() {
+    return new NoopKafkaConsumer<>();
+  }
+}

--- a/nab-testbase/src/main/java/ru/hh/nab/testbase/kafka/NoopKafkaConsumer.java
+++ b/nab-testbase/src/main/java/ru/hh/nab/testbase/kafka/NoopKafkaConsumer.java
@@ -1,0 +1,50 @@
+package ru.hh.nab.testbase.kafka;
+
+import java.util.Collection;
+import java.util.List;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import ru.hh.nab.kafka.consumer.KafkaConsumer;
+
+public class NoopKafkaConsumer<T> extends KafkaConsumer<T> {
+
+  public NoopKafkaConsumer() {
+    super(null, null, null, null);
+  }
+
+  @Override
+  public void start() {
+    // do nothing
+  }
+
+  @Override
+  public void stop(Runnable callback) {
+    // do nothing
+  }
+
+  @Override
+  public void stop() {
+    // do nothing
+  }
+
+  @Override
+  public Collection<TopicPartition> getAssignedPartitions() {
+    return List.of();
+  }
+
+  @Override
+  public void onMessagesBatch(List<ConsumerRecord<String, T>> messages, Consumer<?, ?> consumer) {
+    // do nothing
+  }
+
+  @Override
+  protected void createNewSpringContainer() {
+    // do nothing
+  }
+
+  @Override
+  public void rewindToLastAckedOffset(Consumer<?, ?> consumer) {
+    // do nothing
+  }
+}

--- a/nab-testbase/src/main/java/ru/hh/nab/testbase/kafka/NoopKafkaConsumerFactory.java
+++ b/nab-testbase/src/main/java/ru/hh/nab/testbase/kafka/NoopKafkaConsumerFactory.java
@@ -1,0 +1,43 @@
+package ru.hh.nab.testbase.kafka;
+
+import org.slf4j.Logger;
+import ru.hh.nab.kafka.consumer.ConsumeStrategy;
+import ru.hh.nab.kafka.consumer.ConsumerBuilder;
+import ru.hh.nab.kafka.consumer.KafkaConsumer;
+import ru.hh.nab.kafka.consumer.KafkaConsumerFactory;
+
+public class NoopKafkaConsumerFactory implements KafkaConsumerFactory {
+
+  @Override
+  public <T> KafkaConsumer<T> subscribe(String topicName, String operationName, Class<T> messageClass, ConsumeStrategy<T> consumeStrategy) {
+    return new NoopKafkaConsumer<>();
+  }
+
+  @Override
+  public <T> KafkaConsumer<T> subscribe(
+      String topicName,
+      String operationName,
+      Class<T> messageClass,
+      ConsumeStrategy<T> consumeStrategy,
+      Logger logger
+  ) {
+    return new NoopKafkaConsumer<>();
+  }
+
+  @Override
+  public <T> KafkaConsumer<T> subscribe(
+      String clientId,
+      String topicName,
+      String operationName,
+      Class<T> messageClass,
+      ConsumeStrategy<T> consumeStrategy,
+      Logger logger
+  ) {
+    return new NoopKafkaConsumer<>();
+  }
+
+  @Override
+  public <T> ConsumerBuilder<T> builder(String topicName, Class<T> messageClass) {
+    return new NoopConsumerBuilder<>();
+  }
+}


### PR DESCRIPTION
- [ ] **version change** <!--[MAJOR|MINOR|PATCH]-->: MINOR
- [ ] **description**: В nab-testbase добавлен класс NoopKafkaConsumerFactory, который можно использовать в тестах вместо мокирования. То есть в тестовых спринговых конфигах вместо `mock(KafkaConsumerFactory.class)` можно создавать объект `new NoopKafkaConsumerFactory()`
- [ ] **requires_changes_in_hh** <!-- [true|false] -->: false
- [ ] **instructions** <!-- [if requires_changes_in_hh]-->:
