### PR TITLE
HH-206867 : Bumpb statsd client to 4.4.2

### DIFF
--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/util/ConfigProvider.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/util/ConfigProvider.java
@@ -222,7 +222,7 @@ public class ConfigProvider {
     int maxPacketSizeBytes = ofNullable(fileSettings.getString(STATSD_MAX_PACKET_SIZE_BYTES_PROPERTY))
         .or(() -> ofNullable(System.getProperty(STATSD_MAX_PACKET_SIZE_BYTES_ENV)))
         .map(Integer::parseInt)
-        .orElse(NonBlockingStatsDClient.DEFAULT_MAX_PACKET_SIZE_BYTES);
+        .orElse(NonBlockingStatsDClient.DEFAULT_UDP_MAX_PACKET_SIZE_BYTES);
     properties.put(STATSD_MAX_PACKET_SIZE_BYTES_PROPERTY, maxPacketSizeBytes);
 
     int bufferPoolSize = ofNullable(fileSettings.getString(STATSD_BUFFER_POOL_SIZE_PROPERTY))

--- a/nab-metrics/pom.xml
+++ b/nab-metrics/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.datadoghq</groupId>
             <artifactId>java-dogstatsd-client</artifactId>
-            <version>2.10.5</version>
+            <version>4.4.2</version>
         </dependency>
 
         <dependency>

--- a/nab-starter/src/main/java/ru/hh/nab/starter/NabProdConfig.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/NabProdConfig.java
@@ -83,7 +83,7 @@ public class NabProdConfig {
     int maxPacketSizeBytes = ofNullable(fileSettings.getString(STATSD_MAX_PACKET_SIZE_BYTES_PROPERTY))
         .or(() -> ofNullable(System.getProperty(STATSD_MAX_PACKET_SIZE_BYTES_ENV)))
         .map(Integer::parseInt)
-        .orElse(NonBlockingStatsDClient.DEFAULT_MAX_PACKET_SIZE_BYTES);
+        .orElse(NonBlockingStatsDClient.DEFAULT_UDP_MAX_PACKET_SIZE_BYTES);
 
     int bufferPoolSize = ofNullable(fileSettings.getString(STATSD_BUFFER_POOL_SIZE_PROPERTY))
         .or(() -> ofNullable(System.getProperty(STATSD_BUFFER_POOL_SIZE_ENV)))


### PR DESCRIPTION
> [!IMPORTANT] 
> Добавь в описание PR changelog в формате:

- [ ] **version change** <!--[MAJOR|MINOR|PATCH]-->: MINOR
- [ ] **description**:

1. Updated java-dogstatsd-client to 4.4.2
2. Metrics aggregation enabled by default

- [ ] **requires_changes_in_hh** <!-- [true|false] -->: true
- [ ] **instructions** <!-- [if requires_changes_in_hh]-->: 

1. If you're using StatsDClient directly from java-statsd-client please refer to migration guide https://github.com/DataDog/java-dogstatsd-client?tab=readme-ov-file#migrating-from-2x-to-3x
2. Version 3 has only bugfixes, so migration guide is working for 2-d to 4-th version as well
