### PR TITLE
HH-226576 : Revert "HH-206867 : Bumpb statsd client to 4.4.2"

### DIFF
--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/util/ConfigProvider.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/util/ConfigProvider.java
@@ -222,7 +222,7 @@ public class ConfigProvider {
     int maxPacketSizeBytes = ofNullable(fileSettings.getString(STATSD_MAX_PACKET_SIZE_BYTES_PROPERTY))
         .or(() -> ofNullable(System.getProperty(STATSD_MAX_PACKET_SIZE_BYTES_ENV)))
         .map(Integer::parseInt)
-        .orElse(NonBlockingStatsDClient.DEFAULT_UDP_MAX_PACKET_SIZE_BYTES);
+        .orElse(NonBlockingStatsDClient.DEFAULT_MAX_PACKET_SIZE_BYTES);
     properties.put(STATSD_MAX_PACKET_SIZE_BYTES_PROPERTY, maxPacketSizeBytes);
 
     int bufferPoolSize = ofNullable(fileSettings.getString(STATSD_BUFFER_POOL_SIZE_PROPERTY))

--- a/nab-metrics/pom.xml
+++ b/nab-metrics/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.datadoghq</groupId>
             <artifactId>java-dogstatsd-client</artifactId>
-            <version>4.4.2</version>
+            <version>2.10.5</version>
         </dependency>
 
         <dependency>

--- a/nab-starter/src/main/java/ru/hh/nab/starter/NabProdConfig.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/NabProdConfig.java
@@ -83,7 +83,7 @@ public class NabProdConfig {
     int maxPacketSizeBytes = ofNullable(fileSettings.getString(STATSD_MAX_PACKET_SIZE_BYTES_PROPERTY))
         .or(() -> ofNullable(System.getProperty(STATSD_MAX_PACKET_SIZE_BYTES_ENV)))
         .map(Integer::parseInt)
-        .orElse(NonBlockingStatsDClient.DEFAULT_UDP_MAX_PACKET_SIZE_BYTES);
+        .orElse(NonBlockingStatsDClient.DEFAULT_MAX_PACKET_SIZE_BYTES);
 
     int bufferPoolSize = ofNullable(fileSettings.getString(STATSD_BUFFER_POOL_SIZE_PROPERTY))
         .or(() -> ofNullable(System.getProperty(STATSD_BUFFER_POOL_SIZE_ENV)))


### PR DESCRIPTION
This reverts commit 0660c9e5453a114927dd055f2241bc4b33c169f1.

> [!IMPORTANT] 
> Добавь в описание PR changelog в формате:

- [ ] **version change** <!--[MAJOR|MINOR|PATCH]-->: PATCH
- [ ] **description**:

1. Downgrade java-dogstatsd-client to 2.10.5

- [ ] **requires_changes_in_hh** <!-- [true|false] -->: true
- [ ] **instructions** <!-- [if requires_changes_in_hh]-->: 

1. If you updated to nuts-and-bolts 5.2.0 please revert changes described in instructions to earlier release
