### PR TITLE
HH-227823 up statsd-client

### DIFF
--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/monitoring/KafkaStatsDReporter.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/monitoring/KafkaStatsDReporter.java
@@ -136,6 +136,9 @@ public class KafkaStatsDReporter implements MetricsReporter {
         .hostname(host)
         .queueSize(queueSize)
         .port(port)
+        .enableAggregation(false)
+        .originDetectionEnabled(false)
+        .enableTelemetry(false)
         .maxPacketSizeBytes(maxPacketSizeBytes)
         .bufferPoolSize(bufferPoolSize)
         .build();

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/util/ConfigProvider.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/util/ConfigProvider.java
@@ -229,7 +229,7 @@ public class ConfigProvider {
     int maxPacketSizeBytes = ofNullable(fileSettings.getString(STATSD_MAX_PACKET_SIZE_BYTES_PROPERTY))
         .or(() -> ofNullable(System.getProperty(STATSD_MAX_PACKET_SIZE_BYTES_ENV)))
         .map(Integer::parseInt)
-        .orElse(NonBlockingStatsDClient.DEFAULT_MAX_PACKET_SIZE_BYTES);
+        .orElse(NonBlockingStatsDClient.DEFAULT_UDP_MAX_PACKET_SIZE_BYTES);
     properties.put(STATSD_MAX_PACKET_SIZE_BYTES_PROPERTY, maxPacketSizeBytes);
 
     int bufferPoolSize = ofNullable(fileSettings.getString(STATSD_BUFFER_POOL_SIZE_PROPERTY))

--- a/nab-metrics/pom.xml
+++ b/nab-metrics/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.datadoghq</groupId>
             <artifactId>java-dogstatsd-client</artifactId>
-            <version>2.10.5</version>
+            <version>4.4.2</version>
         </dependency>
 
         <dependency>

--- a/nab-starter/src/main/java/ru/hh/nab/starter/NabProdConfig.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/NabProdConfig.java
@@ -83,7 +83,7 @@ public class NabProdConfig {
     int maxPacketSizeBytes = ofNullable(fileSettings.getString(STATSD_MAX_PACKET_SIZE_BYTES_PROPERTY))
         .or(() -> ofNullable(System.getProperty(STATSD_MAX_PACKET_SIZE_BYTES_ENV)))
         .map(Integer::parseInt)
-        .orElse(NonBlockingStatsDClient.DEFAULT_MAX_PACKET_SIZE_BYTES);
+        .orElse(NonBlockingStatsDClient.DEFAULT_UDP_MAX_PACKET_SIZE_BYTES);
 
     int bufferPoolSize = ofNullable(fileSettings.getString(STATSD_BUFFER_POOL_SIZE_PROPERTY))
         .or(() -> ofNullable(System.getProperty(STATSD_BUFFER_POOL_SIZE_ENV)))
@@ -94,6 +94,9 @@ public class NabProdConfig {
         .hostname(host)
         .queueSize(queueSize)
         .port(port)
+        .enableAggregation(false)
+        .originDetectionEnabled(false)
+        .enableTelemetry(false)
         .maxPacketSizeBytes(maxPacketSizeBytes)
         .bufferPoolSize(bufferPoolSize)
         .build();


### PR DESCRIPTION
> [!IMPORTANT] 
> Добавь в описание PR changelog в формате:

- [ ] **version change** <!--[MAJOR|MINOR|PATCH]-->: MINOR
- [ ] **description**: Обновлен java-dogstatsd-client до 4.4.2. 
- [ ] **requires_changes_in_hh** <!-- [true|false] -->: true
- [ ] **instructions** <!-- [if requires_changes_in_hh]-->: Если вы в коде своего сервиса сами конфигурируете бин StatsDClient, то не делайте так, используйте набовский. Если сервис не на набе, то в NonBlockingStatsDClientBuilder задайте: enableAggregation(false), originDetectionEnabled(false) и enableTelemetry(false). Если этого не сделать, метрики перестанут отправляться
