### PR TITLE
HH-229623 change default statsd buffer pool size from 512 to 8

### DIFF
--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/util/ConfigProvider.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/util/ConfigProvider.java
@@ -235,7 +235,7 @@ public class ConfigProvider {
     int bufferPoolSize = ofNullable(fileSettings.getString(STATSD_BUFFER_POOL_SIZE_PROPERTY))
         .or(() -> ofNullable(System.getProperty(STATSD_BUFFER_POOL_SIZE_ENV)))
         .map(Integer::parseInt)
-        .orElse(NonBlockingStatsDClient.DEFAULT_POOL_SIZE);
+        .orElse(8);
     properties.put(STATSD_BUFFER_POOL_SIZE_PROPERTY, bufferPoolSize);
 
     int sendIntervalSeconds = ofNullable(fileSettings.getInteger(STATSD_DEFAULT_PERIODIC_SEND_INTERVAL))

--- a/nab-starter/src/main/java/ru/hh/nab/starter/NabProdConfig.java
+++ b/nab-starter/src/main/java/ru/hh/nab/starter/NabProdConfig.java
@@ -88,7 +88,7 @@ public class NabProdConfig {
     int bufferPoolSize = ofNullable(fileSettings.getString(STATSD_BUFFER_POOL_SIZE_PROPERTY))
         .or(() -> ofNullable(System.getProperty(STATSD_BUFFER_POOL_SIZE_ENV)))
         .map(Integer::parseInt)
-        .orElse(NonBlockingStatsDClient.DEFAULT_POOL_SIZE);
+        .orElse(8);
 
     return new NonBlockingStatsDClientBuilder()
         .hostname(host)


### PR DESCRIPTION
> [!IMPORTANT] 
> Добавь в описание PR changelog в формате:

- [ ] **version change** <!--[MAJOR|MINOR|PATCH]-->: PATCH
- [ ] **description**: Размер пула StatsD-клиента для отправки метрик сокращен с 512 до 8 по умолчанию
- [ ] **requires_changes_in_hh** <!-- [true|false] -->: false
- [ ] **instructions** <!-- [if requires_changes_in_hh]-->:
