### PR TITLE
HH-239516 TestExecutorListener: get serviceName from junit configurationParameters

### DIFF
--- a/nab-testbase/pom.xml
+++ b/nab-testbase/pom.xml
@@ -48,7 +48,6 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.7.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
> [!IMPORTANT] 
> Добавь в описание PR changelog в формате:

- [ ] **version change** <!--[MAJOR|MINOR|PATCH]-->: MAJOR
- [ ] **description**: TestExecutorListener, отвечающий за сохранение статистики выполнения юнит тестов, получает serviceName из файла junit-platform.properties
- [ ] **requires_changes_in_hh** <!-- [true|false] -->: true
- [ ] **instructions** <!-- [if requires_changes_in_hh]-->: Если в сервисе подключен TestExecutorListener (есть файл src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener и в нем указан ru.hh.nab.testbase.listeners.TestExecutorListener), то необходимо также добавить файл src/test/resources/junit-platform.properties и добавить в него пропертю serviceName (можно скопипастить из service-test.properties). В противном случае статистика выполнения юнит тестов сохранятся не будет
