### PR TITLE
HH-239873 Return ConsumerBuilder::start as deprecated API

### DIFF
--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/ConsumerBuilder.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/ConsumerBuilder.java
@@ -110,4 +110,14 @@ public interface ConsumerBuilder<T> {
   ConsumerBuilder<T> withAllPartitionsAssigned(SeekPosition seekPosition);
 
   KafkaConsumer<T> build();
+
+  /**
+   * @deprecated Use {@link #build()} and then {@link KafkaConsumer#start()}
+   * */
+  @Deprecated(forRemoval = true)
+  default KafkaConsumer<T> start() {
+    KafkaConsumer<T> consumer = build();
+    consumer.start();
+    return consumer;
+  }
 }


### PR DESCRIPTION
> [!IMPORTANT] 
> Добавь в описание PR changelog в формате:

- [ ] **version change** : PATCH
- [ ] **description**: Вернули удаленный в 9.0.0 метод ConsumerBuilder::start с пометкой deprecated
- [ ] **requires_changes_in_hh** : false
- [ ] **instructions** :
