### PR TITLE
HH-241677 : Allow to filter reported metrics

### DIFF
--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/monitoring/KafkaStatsDReporter.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/monitoring/KafkaStatsDReporter.java
@@ -1,8 +1,10 @@
 package ru.hh.nab.kafka.monitoring;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import static java.util.Optional.ofNullable;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.apache.kafka.common.Metric;
@@ -17,19 +19,51 @@ import ru.hh.nab.metrics.Tag;
 
 public class KafkaStatsDReporter implements MetricsReporter {
   private static final Logger LOGGER = LoggerFactory.getLogger(KafkaStatsDReporter.class);
+  static final Set<String> CRITICAL_METRICS = Set.of(
+      "consumer-metrics.last-poll-seconds-ago",
+
+      "consumer-fetch-manager-metrics.records-lag",
+      "consumer-fetch-manager-metrics.records-consumed-rate",
+      "consumer-fetch-manager-metrics.records-per-request-avg",
+      "consumer-fetch-manager-metrics.fetch-rate",
+      "consumer-fetch-manager-metrics.fetch-latency-max",
+      "consumer-fetch-manager-metrics.fetch-throttle-time-max",
+      "consumer-fetch-manager-metrics.bytes-consumed-rate",
+
+      "consumer-coordinator-metrics.commit-latency-max",
+      "consumer-coordinator-metrics.assigned-partitions",
+      "consumer-coordinator-metrics.commit-rate",
+      "consumer-coordinator-metrics.last-rebalance-seconds-ago",
+      "consumer-coordinator-metrics.last-heartbeat-seconds-ago",
+
+      "producer-metrics.request-latency-avg",
+      "producer-metrics.requests-in-flight",
+      "producer-metrics.batch-size-max",
+      "producer-metrics.records-per-request-avg",
+      "producer-metrics.record-queue-time-avg",
+      "producer-metrics.compression-rate-avg",
+      "producer-metrics.produce-throttle-time-max",
+
+      "producer-topic-metrics.record-send-rate",
+      "producer-topic-metrics.record-retry-rate",
+      "producer-topic-metrics.record-error-rate"
+  );
+
+  public static final String METRICS_ALLOWED = "metrics.allowed";
+  public static final String METRICS_SEND_ALL = "metrics.send-all";
   public static final String STATSD_INSTANCE_PROPERTY = "NAB_STATSD_INSTANCE";
 
   private String serviceName;
   private StatsDSender statsDSender;
+  private boolean isSendAll;
+  private Set<String> allowedMetrics;
 
   protected final ConcurrentMap<MetricName, Metric> recordedMetrics = new ConcurrentHashMap<>();
 
   @Override
   public void init(List<KafkaMetric> metrics) {
     for (KafkaMetric metric : metrics) {
-      MetricName metricName = metric.metricName();
-      recordedMetrics.put(metricName, metric);
-      LOGGER.debug("Added metric %s on initialization step".formatted(createMetricName(metricName)));
+      recordMetric(metric);
     }
 
     statsDSender.sendPeriodically(() -> {
@@ -48,10 +82,10 @@ public class KafkaStatsDReporter implements MetricsReporter {
             Tag partitionTag = createTag(tags, ReporterTag.PARTITION);
 
             statsDSender.sendGauge(name, number.doubleValue(), serviceNameTag, nodeIdTag, clientIdTag, topicTag, partitionTag);
-            LOGGER.debug("Sent gauge value %s for metric %s".formatted(value.toString(), name));
+            LOGGER.debug("Sent gauge value {} for metric {}", value, name);
           } else {
             statsDSender.sendSetValue(name, metricValue.toString(), serviceNameTag, nodeIdTag, clientIdTag);
-            LOGGER.debug("Sent set value %s for metric %s".formatted(value.toString(), name));
+            LOGGER.debug("Sent set value {} for metric {}", value, name);
           }
         } catch (Exception e) {
           LOGGER.error("Skipping metric %s".formatted(key), e);
@@ -67,16 +101,14 @@ public class KafkaStatsDReporter implements MetricsReporter {
 
   @Override
   public void metricChange(KafkaMetric metric) {
-    MetricName metricName = metric.metricName();
-    recordedMetrics.put(metricName, metric);
-    LOGGER.debug("Added metric %s".formatted(createMetricName(metricName)));
+    recordMetric(metric);
   }
 
   @Override
   public void metricRemoval(KafkaMetric metric) {
     MetricName metricName = metric.metricName();
     recordedMetrics.remove(metricName);
-    LOGGER.debug("Removed metric %s".formatted(createMetricName(metricName)));
+    LOGGER.debug("Removed metric {}", createMetricName(metricName));
   }
 
   @Override
@@ -86,13 +118,33 @@ public class KafkaStatsDReporter implements MetricsReporter {
 
   @Override
   public void configure(Map<String, ?> configs) {
+    this.isSendAll = ofNullable(configs.get(METRICS_SEND_ALL)).map(value -> Boolean.parseBoolean(value.toString())).orElse(false);
+    String metrics = ofNullable(configs.get(METRICS_ALLOWED)).map(Object::toString).orElse("");
+    this.allowedMetrics = new HashSet<>();
+    if (!metrics.isEmpty() && !metrics.isBlank()) {
+      String[] rawMetricNames = metrics.split(",");
+      for (String rawMetricName : rawMetricNames) {
+        this.allowedMetrics.add(rawMetricName.trim());
+      }
+    }
+    this.allowedMetrics.addAll(CRITICAL_METRICS);
+
     this.serviceName = ofNullable(configs.get(SERVICE_NAME)).map(Object::toString).orElseThrow();
     // A workaround to support a single instance of StatsD client, see ru.hh.nab.kafka.util.ConfigProvider
     this.statsDSender = (StatsDSender) configs.get(STATSD_INSTANCE_PROPERTY);
   }
 
-  private static String createMetricName(MetricName metricName) {
+  // Visible only for tests
+  static String createMetricName(MetricName metricName) {
     return String.format("%s.%s", metricName.group(), metricName.name());
+  }
+
+  private void recordMetric(KafkaMetric metric) {
+    String name = createMetricName(metric.metricName());
+    if (isSendAll || allowedMetrics.contains(name)) {
+      recordedMetrics.put(metric.metricName(), metric);
+      LOGGER.debug("Added metric {}", name);
+    }
   }
 
   public enum ReporterTag {

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/producer/KafkaProducerFactory.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/producer/KafkaProducerFactory.java
@@ -29,10 +29,10 @@ public class KafkaProducerFactory {
       SerializerSupplier serializerSupplier,
       @Nullable Supplier<String> bootstrapServersSupplier
   ) {
-    validateConfig(configProvider, bootstrapServersSupplier, serializerSupplier);
     this.configProvider = configProvider;
     this.serializerSupplier = serializerSupplier;
     this.bootstrapServersSupplier = bootstrapServersSupplier;
+    validateConfig(configProvider, bootstrapServersSupplier, serializerSupplier);
   }
 
   private static void validateConfig(

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/util/ConfigProvider.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/util/ConfigProvider.java
@@ -53,7 +53,9 @@ public class ConfigProvider {
 
   private static final Set<String> SUPPORTED_PROPERTIES = Set.of(
       SERVICE_NAME,
-      KafkaStatsDReporter.STATSD_INSTANCE_PROPERTY
+      KafkaStatsDReporter.STATSD_INSTANCE_PROPERTY,
+      KafkaStatsDReporter.METRICS_ALLOWED,
+      KafkaStatsDReporter.METRICS_SEND_ALL
   );
 
   public ConfigProvider(String serviceName, String kafkaClusterName, FileSettings fileSettings, StatsDSender statsDSender) {
@@ -193,6 +195,16 @@ public class ConfigProvider {
         .map(Object::toString)
         .orElseGet(KafkaStatsDReporter.class::getName);
     properties.put(CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG, metricReporters);
+
+    String metricsSendAll = ofNullable(properties.get(KafkaStatsDReporter.METRICS_SEND_ALL))
+        .map(Object::toString)
+        .orElseGet(Boolean.FALSE::toString);
+    properties.put(KafkaStatsDReporter.METRICS_SEND_ALL, metricsSendAll);
+
+    String enabledMetrics = ofNullable(properties.get(KafkaStatsDReporter.METRICS_ALLOWED))
+        .map(Object::toString)
+        .orElse("");
+    properties.put(KafkaStatsDReporter.METRICS_ALLOWED, enabledMetrics);
 
     // TODO Remove when we leave Okmeter monitoring
     // Okmeter doesn't provide precision better than once a minute


### PR DESCRIPTION
> [!IMPORTANT] 
> Добавь в описание PR changelog в формате:

- [ ] **version change** <!--[MAJOR|MINOR|PATCH]-->: MINOR
- [ ] **description**:

Добавлено

- Добавлена новая опция `metrics.allowed`, которая отвечает за перечень собираемых метрик в добавок к критическим для мониторинга метрикам
- Добавлена новая опция `metrics.send-all` со значением false по умолчанию, которая отвечает за включения сбора метрик без фильтрации с помощью `metrics.allowed`

- [ ] **requires_changes_in_hh** <!-- [true|false] -->: false
- [ ] **instructions** <!-- [if requires_changes_in_hh]-->: N/A
