### PR TITLE
HH-240171: nab-kafka: add `x-retry-receive-topic` header needed by kafka-retry-service

### DIFF
--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/DefaultConsumerBuilder.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/DefaultConsumerBuilder.java
@@ -129,7 +129,7 @@ public class DefaultConsumerBuilder<T> implements ConsumerBuilder<T> {
         } else if (RetryTopics.DEFAULT_PAIR_OF_TOPICS == retryTopics) {
           retryTopics = RetryTopics.defaultPairOfTopics(consumerMetadata);
         }
-        retryService = new RetryService<>(retryProducer, retryTopics.retrySendTopic(), retryPolicyResolver);
+        retryService = new RetryService<>(retryProducer, retryTopics, retryPolicyResolver);
         retryKafkaConsumer = buildRetryKafkaConsumer(retryService);
       }
       return buildKafkaConsumerForConsumerGroup(

--- a/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/retry/HeadersMessageMetadataProvider.java
+++ b/nab-kafka/src/main/java/ru/hh/nab/kafka/consumer/retry/HeadersMessageMetadataProvider.java
@@ -25,10 +25,13 @@ import org.apache.kafka.common.header.Headers;
  *     "lastFailTime" : 1.7302115379555104E9
  *   }
  * </pre>
+ * <p>
+ * Topic name where application expects to receive retry message is stored in {@link #HEADER_RECEIVE_TOPIC}
  * */
 public class HeadersMessageMetadataProvider {
   public static final String HEADER_MESSAGE_PROCESSING_HISTORY = "x-retry-message-processing-history";
   public static final String HEADER_NEXT_RETRY_TIME = "x-retry-next-retry-time";
+  public static final String HEADER_RECEIVE_TOPIC = "x-retry-receive-topic";
   private static final ObjectMapper objectMapper = new ObjectMapper()
       .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
       .registerModule(new JavaTimeModule());
@@ -60,6 +63,17 @@ public class HeadersMessageMetadataProvider {
   }
 
   /**
+   * Get retry receive topic name from message headers
+   * */
+  public static Optional<String> getRetryReceiveTopic(Headers headers) {
+
+    return Optional
+        .ofNullable(headers.lastHeader(HEADER_RECEIVE_TOPIC))
+        .map(Header::value)
+        .map(value -> new String(value, StandardCharsets.UTF_8));
+  }
+
+  /**
    * Store {@link MessageProcessingHistory} to message headers
    * */
   public static void setMessageProcessingHistory(Headers headers, MessageProcessingHistory messageProcessingHistory) {
@@ -82,5 +96,16 @@ public class HeadersMessageMetadataProvider {
     headers
         .remove(HEADER_NEXT_RETRY_TIME)
         .add(HEADER_NEXT_RETRY_TIME, headerValue);
+  }
+
+  /**
+   * Store retry receive topic name to message headers
+   * */
+  public static void setRetryReceiveTopic(Headers headers, RetryTopics retryTopics) {
+    String receiveTopic = retryTopics.retryReceiveTopic();
+    byte[] headerValue = receiveTopic.getBytes(StandardCharsets.UTF_8);
+    headers
+        .remove(HEADER_RECEIVE_TOPIC)
+        .add(HEADER_RECEIVE_TOPIC, headerValue);
   }
 }

--- a/nab-kafka/src/test/java/ru/hh/nab/kafka/consumer/retry/HeadersMessageMetadataProviderTest.java
+++ b/nab-kafka/src/test/java/ru/hh/nab/kafka/consumer/retry/HeadersMessageMetadataProviderTest.java
@@ -9,8 +9,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import static ru.hh.nab.kafka.consumer.retry.HeadersMessageMetadataProvider.getMessageProcessingHistory;
 import static ru.hh.nab.kafka.consumer.retry.HeadersMessageMetadataProvider.getNextRetryTime;
+import static ru.hh.nab.kafka.consumer.retry.HeadersMessageMetadataProvider.getRetryReceiveTopic;
 import static ru.hh.nab.kafka.consumer.retry.HeadersMessageMetadataProvider.setMessageProcessingHistory;
 import static ru.hh.nab.kafka.consumer.retry.HeadersMessageMetadataProvider.setNextRetryTime;
+import static ru.hh.nab.kafka.consumer.retry.HeadersMessageMetadataProvider.setRetryReceiveTopic;
 
 class HeadersMessageMetadataProviderTest {
   static final Instant NOW = Instant.now().truncatedTo(ChronoUnit.MILLIS);
@@ -30,5 +32,13 @@ class HeadersMessageMetadataProviderTest {
     assertTrue(getNextRetryTime(headers).isEmpty());
     setNextRetryTime(headers, NOW);
     assertEquals(NOW, getNextRetryTime(headers).get());
+  }
+
+  @Test
+  void retryReceiveTopic() {
+    Headers headers = new RecordHeaders();
+    assertTrue(getRetryReceiveTopic(headers).isEmpty());
+    setRetryReceiveTopic(headers, new RetryTopics("sendTopic", "receiveTopic"));
+    assertEquals("receiveTopic", getRetryReceiveTopic(headers).get());
   }
 }


### PR DESCRIPTION
- [ ] **version change** <!--[MAJOR|MINOR|PATCH]-->: MINOR
- [ ] **description**: Adding an extra header to the KafkaRecord sent to the retry topic. The header specifies the topic where the retry message is meant to be consumed.
- [ ] **requires_changes_in_hh** <!-- [true|false] -->: false
- [ ] **instructions** <!-- [if requires_changes_in_hh]-->: 