### PR TITLE
HH-244591 write ip instead of unknown in telemetry tracing in case if…

### DIFF
--- a/nab-telemetry/src/main/java/ru/hh/nab/telemetry/TelemetryListenerImpl.java
+++ b/nab-telemetry/src/main/java/ru/hh/nab/telemetry/TelemetryListenerImpl.java
@@ -61,7 +61,10 @@ public class TelemetryListenerImpl implements RequestDebug {
 
 
     builder.setAttribute("http.request.cloud.region", context.getDestinationDatacenter());
-    builder.setAttribute("destination.address", context.getDestinationHost() == null ? UNKNOWN : context.getDestinationHost());
+    builder.setAttribute(
+        "destination.address",
+        context.getDestinationHost() == null ? getExactUriHost(request.getUri()) : context.getDestinationHost()
+    );
 
     span = builder.startSpan();
     LOGGER.trace("span started : {}", span);
@@ -120,4 +123,11 @@ public class TelemetryListenerImpl implements RequestDebug {
   public void onProcessingFinished() {
   }
 
+  private String getExactUriHost(Uri uri) {
+    String host = uri.getHost();
+    if (host == null || host.isBlank()) {
+      return UNKNOWN;
+    }
+    return host;
+  }
 }

--- a/nab-telemetry/src/test/java/ru/hh/nab/telemetry/TelemetryListenerTest.java
+++ b/nab-telemetry/src/test/java/ru/hh/nab/telemetry/TelemetryListenerTest.java
@@ -101,7 +101,7 @@ public class TelemetryListenerTest {
     assertEquals("0000000000000000", span.getParentSpanId());
     assertEquals(url, attributes.get(SemanticAttributes.HTTP_URL));
     assertNull(attributes.get(InternalAttributeKeyImpl.create("http.request.cloud.region", AttributeType.STRING)));
-    assertEquals("unknown", attributes.get(InternalAttributeKeyImpl.create("destination.address", AttributeType.STRING)));
+    assertEquals("127.0.0.1", attributes.get(InternalAttributeKeyImpl.create("destination.address", AttributeType.STRING)));
   }
 
   @Test


### PR DESCRIPTION
… hostname is not in context

https://jira.hh.ru/browse/HH-244591

- [ ] **version change** PATCH
- [ ] **description**: write ip instead of unknown in telemetry tracing in case if hostname is not in context
- [ ] **requires_changes_in_hh** false
